### PR TITLE
Fixes: ENOENT: no such file or directory, open '\node_vlocity\defaultdatapack.json'

### DIFF
--- a/node_vlocity/datapacksbuilder.js
+++ b/node_vlocity/datapacksbuilder.js
@@ -11,7 +11,7 @@ var DataPacksBuilder = module.exports = function(vlocity) {
     this.vlocity = vlocity || {};
 
     this.dataPacksExpandedDefinition = JSON.parse(fs.readFileSync(path.join(__dirname, "datapacksexpanddefinition.json"), 'utf8'));
-    this.defaultDataPack = JSON.parse(fs.readFileSync(path.join(__dirname, 'defaultdatapack.json'), 'utf8'));
+    //this.defaultDataPack = JSON.parse(fs.readFileSync(path.join(__dirname, 'defaultdatapack.json'), 'utf8'));
     this.currentStatus;
     this.currentImportData = {};
 };
@@ -19,7 +19,7 @@ var DataPacksBuilder = module.exports = function(vlocity) {
 DataPacksBuilder.prototype.buildImport = function(importPath, manifest, jobInfo) {
     var self = this;
 
-    var dataPackImport = Object.assign({}, self.defaultDataPack);
+    var dataPackImport = JSON.parse(fs.readFileSync(path.join(__dirname, 'defaultdatapack.json'), 'utf8'));
 
     var MAX_IMPORT_SIZE = 400000;
 

--- a/node_vlocity/datapacksbuilder.js
+++ b/node_vlocity/datapacksbuilder.js
@@ -19,7 +19,7 @@ var DataPacksBuilder = module.exports = function(vlocity) {
 DataPacksBuilder.prototype.buildImport = function(importPath, manifest, jobInfo) {
     var self = this;
 
-    var dataPackImport = JSON.parse(fs.readFileSync('./node_vlocity/defaultdatapack.json', 'utf8'));
+    var dataPackImport = Object.assign({}, self.defaultDataPack);
 
     var MAX_IMPORT_SIZE = 400000;
 


### PR DESCRIPTION
Fixes error, because the path `./node_vlocity/defaultdatapack.json` isn't always correct. Should be relative to the `__dirname` global module variable, that's why I have changed to use the `this.defaultDataPack` because that's read from the right relative path.