### PR TITLE
Changed Grunt-Notify to Node-Notifier

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,8 +1,6 @@
 
 'use strict';
 var loadProperties = require('./grunt/loadProperties.js');
-var path = require('path');
-var fs = require('fs');
 var tasksToLoad = [ 'dataPacksJob' ];
 
 module.exports = function(grunt) {
@@ -10,34 +8,12 @@ module.exports = function(grunt) {
 
   var properties = loadProperties(grunt);
 
-  // at the moment grunt-notify does not support custom logos on windows
-  // and as such we just copy over the grunt logo here 
-  try {
-    var defaultToastLogo = path.resolve(__dirname, './node_modules/grunt-notify/images/grunt-logo.png');
-    var vlocityToastLogo = path.resolve(__dirname, './images/toast-logo.png');
-    fs.createReadStream(vlocityToastLogo).pipe(fs.createWriteStream(defaultToastLogo));  
-  } catch(err) {
-    // we do not want to fail because we can't copy a logo
-    grunt.log.warn("Error while copying logo");
-  }
-
   // Load grunt tasks automatically
   require('load-grunt-tasks')(grunt, {pattern: ['grunt-*', '!grunt-template-jasmine-istanbul']});
 
   grunt.initConfig({
-    properties: properties,
-    // setup notify to use a proper title
-    notify_hooks: {
-      options: {
-        title: "Vlocity deployment tools",
-        success: true, 
-        duration: 5
-      }
-    }
+    properties: properties
   });
-
-  // We need to run notify_hooks to have our options loaded
-  grunt.task.run('notify_hooks');
 
   tasksToLoad.forEach(function(taskName) {
     var config = require('./grunt/' + taskName + 'Task.js')(grunt);

--- a/grunt/dataPacksJobTask.js
+++ b/grunt/dataPacksJobTask.js
@@ -1,19 +1,20 @@
 var request = require('request');
 var yaml = require('js-yaml');
 var fs = require('fs-extra');
+var path = require('path');
+var notifier = require('node-notifier');
 
 var node_vlocity = require('../node_vlocity/vlocity.js');
 
-var notify = require('grunt-notify/lib/notify-lib');
-
 module.exports = function (grunt) {
 
-    var dataPacksJobFolder = './dataPacksJobs';
+    var dataPacksJobFolder = './dataPacksJobs';	
 
 	function dataPacksJob(action, jobName, callback, skipUpload) {
 
 	  	var properties = grunt.config.get('properties');
-	  	
+		var jobStartTime = Date.now();
+
 	  	var vlocity = new node_vlocity({
           username: properties['sf.username'], 
           password: properties['sf.password'], 
@@ -77,21 +78,29 @@ module.exports = function (grunt) {
 	    	vlocity.datapacksjob.runJob(dataPacksJobsData, jobName, action,
 	    		function(result) {
 	    			grunt.log.ok('DataPacks Job Success - ' + action + ' - ' + jobName);
-	 
-					notify({
-			            title: 'DataPacks',
-			            message: 'Success - ' + jobName
-			          });
-                    callback();
-		    	},
-		    	function(result) {
-			    	grunt.fail.warn('DataPacks Job Failed - ' + action + ' - ' + jobName + ' - ' + result.errorMessage);
 					
-			    	notify({
-			            title: 'DataPacks',
-			            message: 'Failed - ' + jobName
-			         });
-                    callback(result);
+					notifier.notify({
+			            title: 'Vlocity deployment tools',
+						message: 'Success - ' + jobName + '\n'+
+								 'Job executed in ' + ((Date.now() - jobStartTime)  / 1000).toFixed(0) + ' second(s)',						
+						icon: path.join(__dirname, '..', 'images', 'toast-logo.png'), 
+						sound: true
+					}, function (err, response) {
+						 callback(result);
+					});
+				},						
+		    	function(result) {
+					grunt.fail.warn('DataPacks Job Failed - ' + action + ' - ' + jobName + ' - ' + result.errorMessage);
+					
+			    	notifier.notify({
+			            title: 'Vlocity deployment tools',
+						message: 'Failed - ' + jobName + '\n'+
+								 'Job executed in ' + ((Date.now() - jobStartTime)  / 1000).toFixed(0) + ' second(s)',						
+						icon: path.join(__dirname, '..', 'images', 'toast-logo.png'), 
+						sound: true
+					}, function (err, response) {
+						 callback(result);
+					});
 			}, skipUpload);
 	    } else {
 	    	grunt.log.error('DataPacks Job Not Found - ' + jobName);

--- a/node_vlocity/datapacksbuilder.js
+++ b/node_vlocity/datapacksbuilder.js
@@ -211,7 +211,7 @@ DataPacksBuilder.prototype.getNextImport = function(importPath, dataPackKeys, si
 
                         if (!singleFile) {
                             parentData.forEach(function(parentKey) {
-                                    if (jobInfo.currentStatus[parentKey.replace(/\s+/g, "-")] == 'Ready') {
+                                if (jobInfo.currentStatus[parentKey.replace(/\s+/g, "-")] == 'Ready') {
                                     needsParents = true;
                                 }
                             });

--- a/node_vlocity/datapacksutils.js
+++ b/node_vlocity/datapacksutils.js
@@ -1,6 +1,10 @@
 var fs = require("fs-extra");
 var path  = require('path');
 
+// use consts for setting the namespace prefix so that we easily can reference it later on in this file
+const namespacePrefix = 'vlocity_namespace';
+const namespaceFieldPrefix = '%' + namespacePrefix + '%__';
+
 var DataPacksUtils = module.exports = function(vlocity) {
 	this.vlocity = vlocity || {};
 
@@ -29,11 +33,12 @@ DataPacksUtils.prototype.isValidSObject = function(dataPackType, SObjectType) {
 }
 
 DataPacksUtils.prototype.getWithoutNamespace = function(field) {
-	return field.substring(field.indexOf('%vlocity_namespace%__') + 21);
+	var nspos = field.indexOf(namespaceFieldPrefix);
+	return nspos != -1 ? field.substring(nspos + namespaceFieldPrefix.length) : field;
 }
 
 DataPacksUtils.prototype.getWithNamespace = function(field) {
-	return '%vlocity_namespace%__' + field;
+	return namespaceFieldPrefix + field;
 }
 
 DataPacksUtils.prototype.getDataField = function(dataPackData) {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "packBuildFile": "grunt --gruntfile=Gruntfile.js --base . --tasks=grunt packBuildFile",
     "packExpandFile": "grunt --gruntfile=Gruntfile.js --base . --tasks=grunt packExpandFile"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vlocityinc/vlocity_build.git"
+  },
   "author": "build@vlocity.com",
   "license": "MIT",
   "engine": "node == 4.3.0",
@@ -29,6 +33,7 @@
     "lodash": "4.17.4",
     "sass.js": "0.10.4",
     "properties": "1.2.1",
-    "request": "2.81.0"
+    "request": "2.81.0",
+    "node-notifier": "^5.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "fs-extra": "3.0.1",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
-    "grunt-notify": "0.4.5",
     "js-yaml": "3.8.4",
     "jsforce": "1.8.0",
     "load-grunt-tasks": "3.4.0",


### PR DESCRIPTION
Grunt-Notify is not maintained anymore and caused not compatibility issue with the latest version of NPM. When using the Vlocity deployment tools on our CI/CD server we noticed that it crashed due to the grunt notify package not being able to load the default toast image.

To resolve the issue I replaced it with the Node-Notifier package which is better maintained and also flexible in the kind of notifications to show. This also allowed me to use a the custom toaster image a more robust way; no need for funky copies during start-up anymore.