### PR TITLE
Improvements for APEX code runner and fix for SCSS compilation randomness

### DIFF
--- a/grunt/dataPacksJobTask.js
+++ b/grunt/dataPacksJobTask.js
@@ -77,8 +77,6 @@ module.exports = function (grunt) {
 
 	    	vlocity.datapacksjob.runJob(dataPacksJobsData, jobName, action,
 	    		function(result) {
-	    			grunt.log.ok('DataPacks Job Success - ' + action + ' - ' + jobName);
-					
 					notifier.notify({
 			            title: 'Vlocity deployment tools',
 						message: 'Success - ' + jobName + '\n'+
@@ -86,20 +84,20 @@ module.exports = function (grunt) {
 						icon: path.join(__dirname, '..', 'images', 'toast-logo.png'), 
 						sound: true
 					}, function (err, response) {
-						 callback(result);
+						grunt.log.ok('DataPacks Job Success - ' + action + ' - ' + jobName);
+						callback(result);
 					});
 				},						
 		    	function(result) {
-					grunt.fail.warn('DataPacks Job Failed - ' + action + ' - ' + jobName + ' - ' + result.errorMessage);
-					
-			    	notifier.notify({
+					notifier.notify({
 			            title: 'Vlocity deployment tools',
 						message: 'Failed - ' + jobName + '\n'+
 								 'Job executed in ' + ((Date.now() - jobStartTime)  / 1000).toFixed(0) + ' second(s)',						
 						icon: path.join(__dirname, '..', 'images', 'toast-logo.png'), 
 						sound: true
 					}, function (err, response) {
-						 callback(result);
+						grunt.fatal('DataPacks Job Failed - ' + action + ' - ' + jobName + ' - ' + (result.errorMessage || result));
+						callback(result);
 					});
 			}, skipUpload);
 	    } else {
@@ -111,7 +109,6 @@ module.exports = function (grunt) {
 	function runTaskForAllJobFiles(taskName, callback)
 	{
         var dataPacksJobsData = {};
-
         var properties = grunt.config.get('properties');
 
 		if (properties['vlocity.dataPacksJobFolder']) {

--- a/node_vlocity/datapacksjob.js
+++ b/node_vlocity/datapacksjob.js
@@ -55,8 +55,6 @@ DataPacksJob.prototype.runJob = function(jobData, jobName, action, onSuccess, on
     var toolingApi = self.vlocity.jsForceConnection.tooling;
 
 	function executeJob() {
-		var prePromise;
-
     	if (jobInfo.preJobApex && jobInfo.preJobApex[action]) {
 
     		// Builds the JSON Array sent to Anon Apex that gets run before deploy
@@ -65,12 +63,12 @@ DataPacksJob.prototype.runJob = function(jobData, jobName, action, onSuccess, on
     			self.vlocity.datapacksbuilder.initializeImportStatus(jobInfo.projectPath + '/' + jobInfo.expansionPath, jobInfo.manifest, jobInfo);
     		}
 
-    		prePromise = self.vlocity.datapacksutils.runApex(jobInfo.projectPath, jobInfo.preJobApex[action], jobInfo.preDeployDataSummary);
+    		var prePromise = self.vlocity.datapacksutils.runApex(jobInfo.projectPath, jobInfo.preJobApex[action], jobInfo.preDeployDataSummary);
     	} else {
-    		prePromise = Promise.resolve(true);
+    		var prePromise = Promise.resolve(true);
     	}
 
-    	prePromise.then(function() {
+    	prePromise.then(function(preDeployResult) {
     		return new Promise(function(resolve, reject) {
     			try {
 	    			self.doRunJob(jobInfo, action, resolve);

--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
   "license": "MIT",
   "engine": "node == 4.3.0",
   "dependencies": {
-    "json-stable-stringify": "1.0.1",
-    "progress": "^2.0.0",
-    "unidecode": "0.1.8",
     "async": "2.4.1",
     "compass-mixins": "0.12.10",
     "fs": "0.0.2",
@@ -28,11 +25,14 @@
     "grunt-cli": "0.1.13",
     "js-yaml": "3.8.4",
     "jsforce": "1.8.0",
+    "json-stable-stringify": "1.0.1",
     "load-grunt-tasks": "3.4.0",
     "lodash": "4.17.4",
-    "sass.js": "0.10.4",
+    "node-notifier": "^5.1.2",
+    "progress": "^2.0.0",
     "properties": "1.2.1",
     "request": "2.81.0",
-    "node-notifier": "^5.1.2"
+    "sass.js": "^0.10.6",
+    "unidecode": "0.1.8"
   }
 }


### PR DESCRIPTION
I made some small improvements in the way APEX is loaded and executed:
- Better error handling when APEX code fails; error message will be shown and the build will be aborted.
- Properly wait for the APEX to execute before running the rest of a deployment job
  - there was an issue with the way the promises where used in the APEX code execution part which cause the promise rejection/resolve not to be returned and instead the APEX execution result object was returned.
- Better handling of errors; when an error occurs it is now logged a bit better and the notification is also shown.
- Fixed bug in SCSS compilation; when compiling SCSS into CSS sass.js would invoke the last passed callback for every compilation result instead of calling the passed callback. This is a bug in sass.js due to which compiling code in Parallel is not really possible. 
  - To resolve this problem SCSS is now compiled in sequence one after another this ensures that the right callbacks are invoked and the compile CSS is assigned to the correct template