### PR TITLE
Support proxy server configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ To begin, create your own property files for your Source and Target Salesforce O
 sf.username: <Salesforce Username>  
 sf.password: <Salesforce Password>  
 ```
+When you (or your CI/CD server) is behind a proxy you can specify the proxy URL with a Username and password by adding the below line to your property file:
+```java
+sf.httpProxy: http://[<Proxy server Username>:<Proxy server Password>@]<Proxy hostname>[:<Proxy Port>]
+```
 
 It is best to not rely on a single build.properties file and instead use named properties files for each org like `build_source.properties` and `build_target.properties`
 

--- a/lib/vlocity.js
+++ b/lib/vlocity.js
@@ -32,6 +32,7 @@ var Vlocity = module.exports = function(options) {
 
     this.jsForceConnection = new jsforce.Connection({
         loginUrl: options.loginUrl ? options.loginUrl : 'https://login.salesforce.com',
+        httpProxy: options.httpProxy ? options.httpProxy : null,
         sessionId: this.sessionId,
         instanceUrl: this.instanceUrl,
         accessToken: this.accessToken

--- a/lib/vlocitycli.js
+++ b/lib/vlocitycli.js
@@ -452,6 +452,7 @@ VlocityCLI.prototype.runJob = function(dataPacksJobsData, jobName, action, succe
           loginUrl: self.optionOrProperty('sf.loginUrl'),
           sessionId: self.optionOrProperty('sf.sessionId'),
           instanceUrl: self.optionOrProperty('sf.instanceUrl'),
+          httpProxy: self.optionOrProperty('sf.httpProxy'),
           verbose: self.optionOrProperty('verbose'),
           performance: self.optionOrProperty('performance')
     });


### PR DESCRIPTION
This add support for specifying a proxy server in the properties files. Readme was also updated to describe the new option. It is set using 'sf.httpProxy' from the properties files which is passed to the sf connect node library that will then proxy all request to salesforce through the proxy server.

We needed this as some of our clients run their CI/CD from servers that can only access the internet through a proxy.