### PR TITLE
Unit Tests initial setup and multilevel expand path support

### DIFF
--- a/lib/datapacksbuilder.js
+++ b/lib/datapacksbuilder.js
@@ -227,36 +227,50 @@ DataPacksBuilder.prototype.countRecords = function(dataPackData) {
     return count;
 };
 
-DataPacksBuilder.prototype.getFileData = function(filePath) {
-
-    return this.allFileDataMap[path.normalize(filePath)];
+DataPacksBuilder.prototype.getFileData = function() {
+    // vari args functions
+    var pathString = arguments.length > 1 ? path.join.apply(this, arguments) : arguments[0];
+    return this.allFileDataMap[path.normalize(pathString).toLowerCase()];
 }
 
 DataPacksBuilder.prototype.setFileData = function(filePath, data) {
-
     if (!this.allFileDataMap) {
         this.allFileDataMap = {};
     }
-    this.allFileDataMap[path.normalize(filePath)] = data;
+    this.allFileDataMap[path.normalize(filePath).toLowerCase()] = data;
 }
 
 DataPacksBuilder.prototype.loadFilesAtPath = function(srcpath, jobInfo, dataPackKey) {
     var self = this;
 
     self.vlocity.datapacksutils.getFiles(srcpath).forEach(function(filename) {
-
         var encoding = 'base64';
-
         var extension = filename.substr(filename.lastIndexOf('.')+1);
-
         if (UTF8_EXTENSIONS.indexOf(extension) > -1) {
             encoding = 'utf8';
         }
-
-        var filemapkey = (srcpath + '/' + filename).toLowerCase();
-        self.setFileData(filemapkey, fs.readFileSync(srcpath + '/' + filename, encoding));
+        var filemapkey = path.normalize(path.join(srcpath, filename));
+        self.setFileData(filemapkey, fs.readFileSync(path.join(srcpath, filename), encoding));
     });
 };
+
+DataPacksBuilder.prototype.getDataPackLabel = function(dataPackTypeDir, dataPackName) {
+    try {        
+        var allFiles = this.vlocity.datapacksutils.getFiles(path.join(dataPackTypeDir, dataPackName));
+        for (var i = 0; i < allFiles.length; i++) {
+            var basename = allFiles[i];//this.vlocity.datapacksutils.getBaseName(allFiles[i]);
+            if (basename.endsWith('_DataPack.json')) {
+               return basename.substr(0, basename.lastIndexOf('_DataPack.json'));
+            }
+        }
+    } catch (e) {
+        // Means file deleted
+        return null;
+    }
+    // file not found
+    return null;
+};
+
 
 DataPacksBuilder.prototype.getDataPackLabel = function(dataPackTypeDir, dataPackName) {
     try {
@@ -311,58 +325,51 @@ DataPacksBuilder.prototype.initializeImportStatus = function(importPath, jobInfo
     importPaths.forEach(function(dataPackType) {
 
         var dataPackTypeDir = importPath + '/' + dataPackType;
-        var allDataPacksOfType = self.vlocity.datapacksutils.getDirectories(dataPackTypeDir);
+        var allDataPacksOfType = self.vlocity.datapacksutils.getDirectories(dataPackTypeDir, true);
+        VlocityUtils.verbose('Found datapack candidates:', allDataPacksOfType.length);
 
-        VlocityUtils.verbose('Found datapacks', allDataPacksOfType);
+        allDataPacksOfType.forEach(function(dataPackName) {
 
-        if (allDataPacksOfType) {
-            allDataPacksOfType.forEach(function(dataPackName) {
+            var dataPackLabel = self.getDataPackLabel(dataPackTypeDir, dataPackName);
+            var dataPackKey = dataPackType + '/' + dataPackName.replace(path.sep, '/');  
+            var metadataFilename = path.join(dataPackTypeDir, dataPackName, dataPackLabel + '_DataPack.json');
 
-                var metadataFilename = dataPackTypeDir + '/' + dataPackName + '/' + self.getDataPackLabel(dataPackTypeDir, dataPackName) + '_DataPack.json';
-                var dataPackKey = dataPackType + '/' + dataPackName;
+            if (dataPackLabel == null || !self.vlocity.datapacksutils.fileExists(metadataFilename))
+                return;                
 
-                try {
-                    if (metadataFilename) {
+            self.loadFilesAtPath(path.join(dataPackTypeDir, dataPackName), jobInfo, dataPackKey);
+            var sobjectData = JSON.parse(self.getFileData(metadataFilename));
+            var generatedDataPackKey = dataPackType + '/' + self.vlocity.datapacksexpand.getDataPackFolder(dataPackType, sobjectData.VlocityRecordSObjectType, sobjectData);
 
-                        if (self.vlocity.datapacksutils.fileExists(metadataFilename)) {
-
-                            self.loadFilesAtPath(dataPackTypeDir + '/' + dataPackName, jobInfo, dataPackKey);
-
-                            var sobjectData = JSON.parse(self.getFileData(metadataFilename.toLowerCase()));
- 
-                            var generatedDataPackKey = dataPackType + '/' + self.vlocity.datapacksexpand.getDataPackFolder(dataPackType, sobjectData.VlocityRecordSObjectType, sobjectData);
-
-                            if (self.isInManifest(jobInfo, dataPackType, generatedDataPackKey, dataPackName)) {
-                            
-                                if (!jobInfo.currentStatus[generatedDataPackKey]) {
-                                    jobInfo.currentStatus[generatedDataPackKey] = 'Ready';
-                                }
-
-                                if (sobjectData.Name) {
-                                    jobInfo.generatedKeysToNames[generatedDataPackKey] = sobjectData.Name;
-                                }
-
-                                if (jobInfo.allParents.indexOf(generatedDataPackKey) == -1) {
-                                    jobInfo.allParents.push(generatedDataPackKey);
-                                }
-
-                                var apexImportData = {};
-
-                                self.vlocity.datapacksutils.getApexImportDataKeys(sobjectData.VlocityRecordSObjectType).forEach(function(field) {
-                                    apexImportData[field] = sobjectData[field];
-                                });
-
-                                apexImportData.VlocityRecordSourceKey = sobjectData.VlocityRecordSourceKey;
-                                jobInfo.preDeployDataSummary.push(apexImportData);
-                                jobInfo.allDataSummary[generatedDataPackKey] = apexImportData;
-                            }
-                        }
-                    }
-                } catch (e) {
-                    VlocityUtils.error('Error Initializing', dataPackKey, e.stack);
+            if (self.isInManifest(jobInfo, dataPackType, generatedDataPackKey, dataPackName)) {
+            
+                if (!jobInfo.currentStatus[generatedDataPackKey]) {
+                    jobInfo.currentStatus[generatedDataPackKey] = 'Ready';
                 }
-            });
-        }
+
+                if (sobjectData.Name) {
+                    jobInfo.generatedKeysToNames[generatedDataPackKey] = sobjectData.Name;
+                }
+
+                if (jobInfo.allParents.indexOf(generatedDataPackKey) == -1) {
+                    jobInfo.allParents.push(generatedDataPackKey);
+                }
+
+                var apexImportData = {};
+
+                self.vlocity.datapacksutils.getApexImportDataKeys(sobjectData.VlocityRecordSObjectType).forEach(function(field) {
+                    apexImportData[field] = sobjectData[field];
+                });
+
+                apexImportData.VlocityRecordSourceKey = sobjectData.VlocityRecordSourceKey;
+                jobInfo.preDeployDataSummary.push(apexImportData);
+                jobInfo.allDataSummary[generatedDataPackKey] = apexImportData;
+            }
+            //         }
+            // } catch (e) {
+            //     VlocityUtils.error('Error Initializing', dataPackKey, e.stack);
+            // }
+        });
     });
 
     if (jobInfo.specificManifestKeys) {
@@ -439,7 +446,7 @@ DataPacksBuilder.prototype.getNextImport = function(importPath, dataPackKeys, si
 
                 // Headers only accounts for potential circular references by only uploading the parent record
                 if (!jobInfo.headersOnly && !jobInfo.forceDeploy) {
-                   parentData = self.getFileData((fullPathToFiles + '/' + dataPackLabel + '_ParentKeys.json').toLowerCase());
+                   parentData = self.getFileData(fullPathToFiles, dataPackLabel + '_ParentKeys.json');
                 } else if (!headersType && !jobInfo.forceDeploy) {
                     continue;
                 }
@@ -509,7 +516,7 @@ DataPacksBuilder.prototype.getNextImport = function(importPath, dataPackKeys, si
                     nextImport.shouldBreakImportLoop = true;
                 }
 
-                var dataPackDataMetadata = JSON.parse(self.getFileData((fullPathToFiles + '/' + dataPackLabel + '_DataPack.json').toLowerCase()));
+                var dataPackDataMetadata = JSON.parse(self.getFileData(fullPathToFiles, dataPackLabel + '_DataPack.json'));
 
                 var sobjectDataField = dataPackDataMetadata.VlocityRecordSObjectType;
 
@@ -595,12 +602,11 @@ DataPacksBuilder.prototype.buildFromFiles = function(dataPackKey, dataPackDataAr
                     var allDataPackFileData = [];
 
                     potentialFileNames.forEach(function(fileInArray) {
-                        var fileInArray = (fullPathToFiles + "/" + fileInArray).toLowerCase();
-
-                        if (self.getFileData(fileInArray)) {
-                             allDataPackFileData = allDataPackFileData.concat(self.buildFromFiles(dataPackKey, JSON.parse(self.getFileData(fileInArray)), fullPathToFiles, dataPackType, field));
+                        var fileData = self.getFileData(fileInArray, fileInArray);
+                        if (fileData) {
+                             allDataPackFileData = allDataPackFileData.concat(self.buildFromFiles(dataPackKey, JSON.parse(fileData), fullPathToFiles, dataPackType, field));
                         } else {
-                            VlocityUtils.error('File Does Not Exist', fileInArray);
+                            VlocityUtils.error('File Does Not Exist', path.join(fileInArray, fileInArray));
                         }
                     });
 
@@ -608,10 +614,9 @@ DataPacksBuilder.prototype.buildFromFiles = function(dataPackKey, dataPackDataAr
                         dataPackData[field] = allDataPackFileData;
                     }
                 } else if (typeof potentialFileNames === 'string') {
-                    var filename = fullPathToFiles + "/" + potentialFileNames;
+                    var filename = path.join(fullPathToFiles, potentialFileNames);
                     var fileType = self.vlocity.datapacksutils.getExpandedDefinition(dataPackType, currentDataField, field);
-
-                    var fileData = self.getFileData(filename.toLowerCase());
+                    var fileData = self.getFileData(filename);
 
                     if (fileData) {
                         var fileDataJSON;
@@ -623,7 +628,6 @@ DataPacksBuilder.prototype.buildFromFiles = function(dataPackKey, dataPackDataAr
                         }
 
                         if (fileDataJSON && ((fileDataJSON[0] && fileDataJSON[0].VlocityRecordSObjectType) || fileDataJSON.VlocityRecordSObjectType)) {
-
                             dataPackData[field] = self.buildFromFiles(dataPackKey, fileDataJSON, fullPathToFiles, dataPackType, field);
                         } else {
                             if (self.compileOnBuild && fileType.CompiledField) { 

--- a/lib/datapacksexpand.js
+++ b/lib/datapacksexpand.js
@@ -9,93 +9,77 @@ var DataPacksExpand = module.exports = function(vlocity) {
 };
 
 DataPacksExpand.prototype.generateFolderPath = function(dataPackType, parentName) {
-    var self = this;
     //Replace spaces with dash (-) to have a valid file name for cards
-    var validParentName = self.generateFolderOrFilename(parentName);
-
-    return self.targetPath + "/" + dataPackType + "/" + validParentName + "/";
+    var validParentName = this.generateFolderOrFilename(parentName);
+    return path.normalize(path.join(this.targetPath, dataPackType, validParentName, path.sep));
 };
 
-
 DataPacksExpand.prototype.generateFolderOrFilename = function(filename, extension) {
-
-    var sanitizedFilename = unidecode(filename).replace(/%vlocity_namespace%__/g,"").replace(/[^A-Za-z0-9_\-]/g, "-");
-
-    if (extension 
-        && extension != "base64" 
-        && !this.vlocity.datapacksutils.endsWith(filename, "." + extension)) {
+    var sanitizedFilename = unidecode(filename)
+        .replace(/%vlocity_namespace%__/g,"")
+        .replace("\\","-") // Regex / also matches \ on windows ..
+        .replace(/[^A-Za-z0-9/_\-]+/g, "-")
+        .replace(/[-]+/g, "-")
+        .replace(/[-_]+_/g, "_")
+        .replace(/[-]+\/[-]+/g, "/")   
+        .replace(/^[-_\\/]+/, "")
+        .replace(/[-_\\/]+$/, "");
+        
+    if (extension && 
+        extension != "base64"  && 
+        !this.vlocity.datapacksutils.endsWith(filename, "." + extension)) {
         sanitizedFilename += "." + extension;
     }
-
     return sanitizedFilename;
-}
+};
 
 DataPacksExpand.prototype.sanitizeDataPackKey = function(key) {
-    var slashIndex = key.indexOf('/');
-    var beforeSlash = key.substring(0, slashIndex);
-    var afterSlash = key.substring(slashIndex+1);
-
-    return beforeSlash + '/' + this.generateFolderOrFilename(key);
-}
+    return this.generateFolderOrFilename(key);
+};
 
 //Generate the full file path
 DataPacksExpand.prototype.generateFilepath = function(dataPackType, parentName, filename, extension) {
-    var self = this;
-
-    var validFileName = self.generateFolderOrFilename(filename, extension);
-
-    return self.generateFolderPath(dataPackType, parentName) + validFileName; 
+    var validFileName = this.generateFolderOrFilename(filename, extension);
+    return this.generateFolderPath(dataPackType, parentName) + validFileName; 
 };
 
 DataPacksExpand.prototype.getNameWithFields = function(nameFields, dataPackData) {
     var self = this;
-    var filename = "";
-
-    if (nameFields) {
-        nameFields.forEach(function(key) {
-
-            if (filename != "") {
-                filename += "_";
-            }
-    
-            // If key references a field adds that otherwise is literal string
-            if (key.indexOf('_') == 0) {
-                filename += key.substring(1);
-            } else if (dataPackData[key] && (typeof dataPackData[key] === "string" || typeof dataPackData[key] === "number")) {
-                filename += dataPackData[key];
-            }
-            else if (typeof dataPackData[key] === "object") {
-                filename += self.getDataPackFolder(null, dataPackData[key].VlocityRecordSObjectType, dataPackData[key]);
-            }
-        });
-    }
-
-    if (filename == "") {
-        if (dataPackData.Name && typeof dataPackData.Name === "string") {
-            filename += dataPackData.Name;
-        } else {
-            filename = null;
+    var processedNames = (nameFields || []).map(function(key) {
+        // If key references a field adds that otherwise is literal string
+        if (key.indexOf('_') == 0) {
+            return key.substring(1);
+        } else if (key == '/' || key == '\\'){
+            return '/'
+        } else if (dataPackData[key] && (typeof dataPackData[key] === "string" || typeof dataPackData[key] === "number")) {
+            return dataPackData[key].replace(/[/\\]+/g,' '); // do not allow directory slashes in names
+        } else if (typeof dataPackData[key] === "object") {
+            return self.getDataPackFolder(null, dataPackData[key].VlocityRecordSObjectType, dataPackData[key]);
         }
-    }
+    });    
 
-    return filename;
+    if (processedNames.length == 0) {
+        if (dataPackData.Name && typeof dataPackData.Name === "string")
+            return dataPackData.Name;
+    } else {
+        var name = processedNames.join('_').replace(/_(\/|\\)_/g, '/').trim('_', '/', '\\');
+        return name;
+    }
+    return name;
 };
 
 DataPacksExpand.prototype.getDataPackName = function(dataPackType, sObjectType, dataPackData) {
-    var self = this;
-    var name = self.getNameWithFields(self.vlocity.datapacksutils.getFileName(dataPackType, sObjectType), dataPackData);
+    var name = this.getNameWithFields(this.vlocity.datapacksutils.getFileName(dataPackType, sObjectType), dataPackData);
     return name ? name : dataPackType;
 };
 
 DataPacksExpand.prototype.getListFileName = function(dataPackType, sObjectType, dataPackData) {
-    var self = this;
-    var name = self.getNameWithFields(self.vlocity.datapacksutils.getListFileName(dataPackType, sObjectType), dataPackData);
+    var name = this.getNameWithFields(this.vlocity.datapacksutils.getListFileName(dataPackType, sObjectType), dataPackData);
     return name ? name : dataPackType;
 };
 
 DataPacksExpand.prototype.getDataPackFolder = function(dataPackType, sObjectType, dataPackData) {
-    var self = this;
-    return self.getNameWithFields(self.vlocity.datapacksutils.getFolderName(dataPackType, sObjectType), dataPackData);
+    return this.getNameWithFields(this.vlocity.datapacksutils.getFolderName(dataPackType, sObjectType), dataPackData);
 };
 
 DataPacksExpand.prototype.sortList = function(listData, dataPackType) {
@@ -103,7 +87,7 @@ DataPacksExpand.prototype.sortList = function(listData, dataPackType) {
 
     if (listData.length > 0 && typeof listData[0] === "object" && listData[0].VlocityRecordSObjectType) {
         var sObjectType = listData[0].VlocityRecordSObjectType;
-
+        
         var sortFields = self.vlocity.datapacksutils.getSortFields(dataPackType, sObjectType);
 
         var listDataBefore = stringify(listData);

--- a/lib/datapacksjob.js
+++ b/lib/datapacksjob.js
@@ -1395,7 +1395,7 @@ DataPacksJob.prototype.deployJob = function(jobInfo, onComplete) {
                                         jobInfo.hasError = true;
                                         atLeastOneRecordHasError = true;
 
-                                        var errorMessage = dataPack.VlocityDataPackKey + ' --- ' + dataPack.VlocityDataPackName;
+                                        var errorMessage = dataPack.VlocityDataPackKey + ' --- ' + dataPack.VlocityDataPackName + ' --- ' + (dataPack.VlocityDataPackMessage ? dataPack.VlocityDataPackMessage.trim() : '');
 
                                         VlocityUtils.error('Deployed Status Not Changed', errorMessage);
 

--- a/lib/datapacksutils.js
+++ b/lib/datapacksutils.js
@@ -302,14 +302,23 @@ DataPacksUtils.prototype.getAllSObjectIds = function(currentData, currentIdsOnly
     }
 };
 
-DataPacksUtils.prototype.getDirectories = function(srcpath) {
-    try {
-        return fs.readdirSync(srcpath).filter(function(file) {
-            return fs.statSync(path.join(srcpath, file)).isDirectory() && fs.readdirSync(path.join(srcpath, file)).length > 0;
-        });
+DataPacksUtils.prototype.getDirectories = function(srcpath, recusive, rootpath) {
+	var dirs = [];
+	try {        
+        rootpath = path.normalize(rootpath || srcpath);
+        fs.readdirSync(srcpath).forEach((file) => {
+            var fullname = path.join(srcpath, file);
+            var fstat = fs.statSync(fullname);
+            if (fstat.isDirectory()) {
+                dirs.push(fullname.substr(rootpath.length + path.sep.length));
+                if(recusive) {
+                    dirs = dirs.concat(this.getDirectories(fullname, recusive, rootpath || srcpath))
+                }
+            }
+        });        
     } catch(e) {
-        return [];
-    }
+	}   
+	return dirs;
 };
 
 DataPacksUtils.prototype.getFiles = function(srcpath) {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
     },
     "description": "",
     "devDependencies": {
+        "chai": "^4.1.2",
         "grunt": "0.4.5",
         "grunt-cli": "1.2.0",
+        "mocha": "^5.0.0",
         "pkg": "4.2.0"
     },
     "engines": {},
@@ -51,7 +53,8 @@
         "refreshVlocityBase": "vlocity refreshVlocityBase",
         "runJavaScript": "vlocity runJavaScript -job DataPacksJob.yaml",
         "test": "vlocity runTestJob",
-        "build": "pkg . --out-path ./bin"
+        "unitTest": "mocha test/**/**.spec.js",
+        "build": "pkg . --out-path ./bin"        
     },
     "version": "1.1.0"
 }

--- a/test/datapacksexpand.spec.js
+++ b/test/datapacksexpand.spec.js
@@ -1,0 +1,69 @@
+'use strict'
+
+const _datapacksexpand = require('../lib/datapacksexpand');
+const expect = require('chai').expect;
+
+describe('DataPacksExpand', () => 
+{
+  var datapacksexpand = new _datapacksexpand();
+  
+  it('should not be null', () => { 
+    expect(_datapacksexpand).to.not.be.eq(null);
+    expect(datapacksexpand).to.not.be.eq(null)
+  }) 
+  
+  describe('generateFolderOrFilename', () => {
+    it('should be a function', () => {
+      expect(datapacksexpand.generateFolderOrFilename).to.be.a('function')
+    })
+    it('should replace namespace placeholder', () => {
+      var name = '%vlocity_namespace%__NameSpace';
+      expect(datapacksexpand.generateFolderOrFilename(name)).to.be.eq('NameSpace');
+    })
+    it('should replace all non asci characters with including spaces a dash (-)', () => {
+      var name = '1$2%3^4(a*b:c\\d';
+      expect(datapacksexpand.generateFolderOrFilename(name)).to.be.eq('1-2-3-4-a-b-c-d');
+    })
+    it('should replace multiple invalid characters in sequence with a single dash', () => {
+      var name = '1!@#$%^&*()*&^%$#@$%^&2';
+      expect(datapacksexpand.generateFolderOrFilename(name)).to.be.eq('1-2');
+    })
+    it('should replace extra dashes (1) before the key seperator', () => {
+      var name = 'a$/$b';
+      expect(datapacksexpand.generateFolderOrFilename(name)).to.be.eq('a/b');
+    })
+    it('should trim dashes from right side and left side', () => {
+      var name = '#%#%#1!@#$%^&*()*&^%$#@$%^&2#$%^&*()';
+      expect(datapacksexpand.generateFolderOrFilename(name)).to.be.eq('1-2');
+    })
+    it('should trim key seperators right side and left side', () => {
+      var name = '#$%^&*/#%#%#1!@#$%^&*()*&^%$#@$%^&2#$%^&*()/$%^&*&^/%^&*&^%^&';
+      expect(datapacksexpand.generateFolderOrFilename(name)).to.be.eq('1-2');
+    })
+    it('should trim ()', () => {
+      var name = 'a (a-b)';
+      expect(datapacksexpand.generateFolderOrFilename(name)).to.be.eq('a-a-b');
+    })    
+  })
+
+  describe('getNameWithFields', () => { 
+    it('should be a function', () => {
+      expect(datapacksexpand.getNameWithFields).to.be.a('function')
+    })
+    it('should replace names with data in supplied name field order', () => {
+      var names = ['Family', 'Name'];
+      var data = {'Name': '1', 'Family': '2'};
+      expect(datapacksexpand.getNameWithFields(names, data)).to.be.eq('2_1');
+    })
+    it('should treat names prefixed with _ as static values', () => {
+      var names = ['Family', '_Name'];
+      var data = {'Name': '1', 'Family': '2'};
+      expect(datapacksexpand.getNameWithFields(names, data)).to.be.eq('2_Name');
+    })
+    it('should both / and \\ as key seperatros replacing them with /', () => {
+      var names = ['Family', '/', 'Name', '\\' , 'Family'];
+      var data = {'Name': '1', 'Family': '2'};
+      expect(datapacksexpand.getNameWithFields(names, data)).to.be.eq('2/1/2');
+    })
+  })
+})


### PR DESCRIPTION
This PR adds support for unit testing functions using mocha, also it includes a few tests for datapackexpand  class for testing the path generation and naming functions that were modified for better multi path support.

Multi path support enables the path slashes in the expand folder path for data packs allowing for a more structured setup of the data in a source control environment. It will allow products to be stored in a a logical folder structure based for example; <ProductFamily>/<ProductBrand>/<ProductName>. For a large product catalog of mobile phones it would generate an expanded structure such as: Handset/Samsung/Galaxy-s7, Handset/Apple/Iphone-8, etc.

Change is generic and not limited to products, it also works for other datapack types. Using the override settings in the YAML file the default path can be changed. Note that you can either use the escaped slash '_/' or just a normal slash '/'. Both back and forward slashes are supported, for key generation compatibility they are always converted to a \ slash.