### PR TITLE
Feature/better error reporting

### DIFF
--- a/lib/datapacksjob.js
+++ b/lib/datapacksjob.js
@@ -1402,9 +1402,9 @@ DataPacksJob.prototype.deployJob = function(jobInfo, onComplete) {
                                         atLeastOneRecordHasError = true;
 
                                         var errorMessage = [
-                                            dataPack.VlocityDataPackKey, 
-                                            'Name  - ' + dataPack.VlocityDataPackName, 
-                                            'Error - ' + (dataPack.VlocityDataPackMessage || 'No error message from server')
+                                            '  ' + dataPack.VlocityDataPackKey, 
+                                            'Datapack >> ' + dataPack.VlocityDataPackName, 
+                                            'Error >> ' + (dataPack.VlocityDataPackMessage || 'No error message from server')
                                         ].map(v => v.trim()).join('\n    ');
 
                                         VlocityUtils.error('Deploy Error', errorMessage);

--- a/lib/datapacksjob.js
+++ b/lib/datapacksjob.js
@@ -1395,25 +1395,21 @@ DataPacksJob.prototype.deployJob = function(jobInfo, onComplete) {
                                                 }
                                             });
                                         }
-                                    } else if (dataPack.VlocityDataPackStatus == 'Error') {
+                                    } else if (dataPack.VlocityDataPackStatus == 'Error' || 
+                                                dataPack.VlocityDataPackStatus == 'Ignored' || 
+                                                dataPackData.dataPacks.length == 1) {
                                         jobInfo.hasError = true;
                                         atLeastOneRecordHasError = true;
 
-                                        var errorMessage = dataPack.VlocityDataPackKey + ' --- '+ dataPack.VlocityDataPackName + ' --- ' + (dataPack.VlocityDataPackMessage ? dataPack.VlocityDataPackMessage.trim() : '');
+                                        var errorMessage = [
+                                            dataPack.VlocityDataPackKey, 
+                                            'Name  - ' + dataPack.VlocityDataPackName, 
+                                            'Error - ' + (dataPack.VlocityDataPackMessage || 'No error message from server')
+                                        ].map(v => v.trim()).join('\n    ');
 
                                         VlocityUtils.error('Deploy Error', errorMessage);
-
-                                        jobInfo.errors.push('Deploy Error >> ' + errorMessage);
-                                    } else if (dataPackData.dataPacks.length == 1) {
-                                        jobInfo.hasError = true;
-                                        atLeastOneRecordHasError = true;
-
-                                        var errorMessage = dataPack.VlocityDataPackKey + ' --- ' + dataPack.VlocityDataPackName;
-
-                                        VlocityUtils.error('Deployed Status Not Changed', errorMessage);
-
-                                        jobInfo.errors.push('Deployed Status Not Changed >> ' + errorMessage);
-                                        jobInfo.currentStatus[dataPack.VlocityDataPackKey] = 'Error';  
+                                        jobInfo.errors.push(errorMessage);
+                                        jobInfo.currentStatus[dataPack.VlocityDataPackKey] = 'Error';
                                     }
                                 });
 

--- a/lib/datapacksutils.js
+++ b/lib/datapacksutils.js
@@ -734,17 +734,18 @@ DataPacksUtils.prototype.printJobStatus = function(jobInfo) {
         return;
     }
     
-    var statusCounts = {
-        Remaining: 0,
-        Success: 0,
-        Error: 0
+    var statusCount = { Remaining: 0, Success: 0, Error: 0 };
+    var statusReportFunc = {
+        Success: VlocityUtils.success,
+        Error: VlocityUtils.error,
+        Remaining: VlocityUtils.warn,
     };
     var statusKeyMap = {
         'Ready': 'Remaining',
         'Header': 'Remaining',
         'Added': 'Remaining',
         'ReadySeparate': 'Remaining'
-    }
+    };
     var keysByStatus = {};
     
     Object.keys(jobInfo.currentStatus).forEach(function(dataPackKey) { 
@@ -752,7 +753,7 @@ DataPacksUtils.prototype.printJobStatus = function(jobInfo) {
         // Count statuses by status type
         var status = jobInfo.currentStatus[dataPackKey];
         status = statusKeyMap[status] || status;
-        statusCount[status] = (statusCount[countKey] || 0) + 1;
+        statusCount[status] = (statusCount[status] || 0) + 1;
         keysByStatus[status] = keysByStatus[status] || {};
 
         // For Exports        
@@ -808,7 +809,7 @@ DataPacksUtils.prototype.printJobStatus = function(jobInfo) {
     VlocityUtils.report('Parallel Processing', jobInfo.supportParallel ? 'On' : 'Off');
     VlocityUtils.report('Force Deploy', jobInfo.forceDeploy ? 'On' : 'Off');
     VlocityUtils.report('Current Status', jobInfo.jobAction);
-    Object.keys(status => VlocityUtils.report(status, statusCount[status]));
+    Object.keys(statusCount).forEach(status => (statusReportFunc[status] || VlocityUtils.report)(status, statusCount[status]));
     VlocityUtils.report('Elapsed Time', Math.floor((elapsedTime / 60)) + 'm ' + Math.floor((elapsedTime % 60)) + 's');
 
     if (jobInfo.hasError) {

--- a/lib/datapacksutils.js
+++ b/lib/datapacksutils.js
@@ -730,37 +730,32 @@ DataPacksUtils.prototype.countRemainingInManifest = function(jobInfo) {
 
 DataPacksUtils.prototype.printJobStatus = function(jobInfo) {
 
-    var totalRemaining = 0;
-    var successfulCount = 0;
-    var errorsCount = 0;
-    var ignoredCount = 0;
-
     if (!jobInfo.currentStatus) {
         return;
     }
-
+    
+    var statusCounts = {
+        Remaining: 0,
+        Success: 0,
+        Error: 0
+    };
+    var statusKeyMap = {
+        'Ready': 'Remaining',
+        'Header': 'Remaining',
+        'Added': 'Remaining',
+        'ReadySeparate': 'Remaining'
+    }
     var keysByStatus = {};
     
     Object.keys(jobInfo.currentStatus).forEach(function(dataPackKey) { 
 
+        // Count statuses by status type
         var status = jobInfo.currentStatus[dataPackKey];
-        if (jobInfo.currentStatus[dataPackKey] == 'Ready' 
-            || jobInfo.currentStatus[dataPackKey] == 'Header' 
-            || jobInfo.currentStatus[dataPackKey] == 'Added'
-            || jobInfo.currentStatus[dataPackKey] == 'ReadySeparate') {
-            status = 'Remaining';
-                totalRemaining++;
-        } else if (jobInfo.currentStatus[dataPackKey] == 'Error') {
-            errorsCount++;
-        } else {
-            errorsCount++;
-        }
+        status = statusKeyMap[status] || status;
+        statusCount[status] = (statusCount[countKey] || 0) + 1;
+        keysByStatus[status] = keysByStatus[status] || {};
 
-        if (!keysByStatus[status]) {
-            keysByStatus[status] = {};
-        }
-
-        // For Exports
+        // For Exports        
         var keyForStatus = jobInfo.vlocityKeysToNewNamesMap[dataPackKey] ? jobInfo.vlocityKeysToNewNamesMap[dataPackKey] : dataPackKey;
 
         if (keyForStatus.indexOf('/') != -1) {
@@ -788,27 +783,18 @@ DataPacksUtils.prototype.printJobStatus = function(jobInfo) {
         || jobInfo.jobAction == 'GetDiffs'
         || jobInfo.jobAction == 'GetDiffsAndDeploy') {
         this.countRemainingInManifest(jobInfo);
-        totalRemaining = jobInfo.exportRemaining;
+        statusCount.Remaining = jobInfo.exportRemaining; 
     }
 
-    if (totalRemaining == 0 
-        && successfulCount == 0 
-        && errorsCount == 0) {
+    var totalCount = Object.values(statusCount).reduce((a,b) => a+b);
+    if (totalCount == 0) {
         return;
     }
 
     var elapsedTime = (Date.now() - jobInfo.startTime) / 1000;
-
+    
     if (jobInfo.headersOnly) {
         VlocityUtils.report('Uploading Only Parent Objects');
-    }
-
-    if (!jobInfo.supportParallel) {
-        VlocityUtils.report('Parallel Processing', 'Off');
-    }
-
-    if (jobInfo.forceDeploy) {
-        VlocityUtils.report('Force Deploy', 'On');
     }
 
     if (jobInfo.ignoreAllParents) {
@@ -819,10 +805,10 @@ DataPacksUtils.prototype.printJobStatus = function(jobInfo) {
         VlocityUtils.report('Salesforce Org', this.vlocity.username);
     }
     
+    VlocityUtils.report('Parallel Processing', jobInfo.supportParallel ? 'On' : 'Off');
+    VlocityUtils.report('Force Deploy', jobInfo.forceDeploy ? 'On' : 'Off');
     VlocityUtils.report('Current Status', jobInfo.jobAction);
-    VlocityUtils.success('Successful', successfulCount);
-    VlocityUtils.error('Errors', errorsCount);
-    VlocityUtils.warn( 'Remaining', totalRemaining);
+    Object.keys(status => VlocityUtils.report(status, statusCount[status]));
     VlocityUtils.report('Elapsed Time', Math.floor((elapsedTime / 60)) + 'm ' + Math.floor((elapsedTime % 60)) + 's');
 
     if (jobInfo.hasError) {

--- a/lib/datapacksutils.js
+++ b/lib/datapacksutils.js
@@ -752,8 +752,8 @@ DataPacksUtils.prototype.printJobStatus = function(jobInfo) {
                 totalRemaining++;
         } else if (jobInfo.currentStatus[dataPackKey] == 'Error') {
             errorsCount++;
-        } else if (jobInfo.currentStatus[dataPackKey] == 'Success') {
-            successfulCount++;
+        } else {
+            errorsCount++;
         }
 
         if (!keysByStatus[status]) {


### PR DESCRIPTION
This pull requests aims to improve the way deploy errors are reported and tries to be more robust in counting the datapack deployments. When running the latest version of the master branch we noticed errors were not always tracked properly. This made it  hard to debug deployment problems.

I noticed that when running with ignore errors on no errors were at all reported back, even though an error message was send back by salesforce. This PR removes the distinction between ignored and error statuses by treating them both as errors and reporting the error message in the console. The format of the error message is slight changed to:
` Deploy error:   [DataPack Key that errored]`
`    Datapack >> [DataPack Name]`
`    Error >> [Error Message from SF]`

Next to that I noticed that the reporting back of the count of the deploy status was not always adding up to. I.e; the deployment started with 191 datapacks. After being about 1 minute in the deploy the status summary would be:
`Successfull: 89`
`Remaining: 100`
`Error: 0`

Somehow 2 datapacks went missing, this was caused by the fact that the counting of datapack statuses could not handle statuses that it didn't expect. In my case status `ignored`, to avoid this and have a more robust way of counting datapacks I rewrote the logic to use a map that can handle any status tag so that the numbers always add up.  
