### PR TITLE
Add support for loading multiple pre-job and post-job apex files.

### DIFF
--- a/lib/datapacksbuilder.js
+++ b/lib/datapacksbuilder.js
@@ -69,11 +69,11 @@ DataPacksBuilder.prototype.buildImport = function(importPath, jobInfo, typesInAl
         nextImport = self.getNextImport(importPath, Object.keys(jobInfo.currentStatus), jobInfo.singleFile === true, jobInfo, typesInAllImports, currentDataPackKeysInImport,currentTypesInImport, !jobInfo.singleFile ? dataPackImportLength : 0);
 
         if (nextImport) {
-           
-           if (!jobInfo.singleFile && Object.keys(currentDataPackKeysInImport).length > 1 && (stringify(nextImport).length > maxImportSize)) {
 
-                if (self.needsPagination(nextImport, jobInfo)) {
-                    var paginated = self.paginateDataPack(nextImport, jobInfo);
+            dataPackImportLength += stringify(nextImport).length;
+
+            if (self.needsPagination(nextImport, jobInfo)) {
+                var paginated = self.paginateDataPack(nextImport, jobInfo);
 
                 if (paginated.length == 0) {
                     paginated = [ nextImport ];
@@ -89,19 +89,18 @@ DataPacksBuilder.prototype.buildImport = function(importPath, jobInfo, typesInAl
             currentDataPackKeysInImport[nextImport.VlocityDataPackKey] = true;
             currentTypesInImport[nextImport.VlocityDataPackType] = true;
             typesInAllImports[nextImport.VlocityDataPackType] = true;
-                
-                if (!jobInfo.singleFile && (Object.keys(currentDataPackKeysInImport).length == self.vlocity.datapacksutils.getMaxDeploy(nextImport.VlocityDataPackType) || nextImport.shouldBreakImportLoop)) {
-                    delete nextImport.shouldBreakImportLoop;
-                    break;
-                }
+            
+            if (!jobInfo.singleFile && (Object.keys(currentDataPackKeysInImport).length == self.vlocity.datapacksutils.getMaxDeploy(nextImport.VlocityDataPackType) || nextImport.shouldBreakImportLoop)) {
+                delete nextImport.shouldBreakImportLoop;
+                break;
             }
+        } 
     } while (nextImport && (jobInfo.singleFile || (dataPackImportLength < self.maxImportSize && dataPackImport.dataPacks.length < maxImportCount)));
 
     if (dataPackImport.dataPacks.length > 0) {
         VlocityUtils.success('Deploy', dataPackImport.dataPacks.length, 'Items');
-        }
-    } while (nextImport && (jobInfo.singleFile || (stringify(dataPackImport).length < maxImportSize && dataPackImport.dataPacks.length < maxImportCount)));
-
+    }
+   
     self.compileQueuedData(result => {
         if(result.hasErrors && !jobInfo.singleFile) {            
             jobInfo.hasError = true;
@@ -240,26 +239,26 @@ DataPacksBuilder.prototype.countRecords = function(dataPackData) {
 
     var count = 0;
     if (dataPackData) {
-    if (dataPackData.VlocityDataPackData) {
-        var dataPackType = dataPackData.VlocityDataPackType;
+        if (dataPackData.VlocityDataPackData) {
+            var dataPackType = dataPackData.VlocityDataPackType;
 
-        var dataField = self.vlocity.datapacksutils.getDataField(dataPackData);
+            var dataField = self.vlocity.datapacksutils.getDataField(dataPackData);
 
-        if (dataField) {
-            count += self.countRecords(dataPackData.VlocityDataPackData[dataField][0]);
+            if (dataField) {
+                count += self.countRecords(dataPackData.VlocityDataPackData[dataField][0]);
+            }
+        } else { 
+            if (Array.isArray(dataPackData)) {
+                dataPackData.forEach(function(childData) {
+                    count += self.countRecords(childData);
+                });
+            } else if (dataPackData.VlocityDataPackType == 'SObject') {
+                Object.keys(dataPackData).forEach(function(key) {
+                    count += self.countRecords(dataPackData[key]);
+                });
+                count++;
+            }
         }
-    } else { 
-        if (Array.isArray(dataPackData)) {
-            dataPackData.forEach(function(childData) {
-                count += self.countRecords(childData);
-            });
-        } else if (dataPackData.VlocityDataPackType == 'SObject') {
-            Object.keys(dataPackData).forEach(function(key) {
-                count += self.countRecords(dataPackData[key]);
-            });
-            count++;
-        }
-    }
     }
 
     return count;
@@ -347,7 +346,7 @@ DataPacksBuilder.prototype.getDataPackLabel = function(dataPackTypeDir, dataPack
 
 DataPacksBuilder.prototype.isInManifest = function(jobInfo, dataPackType, dataPackKey, dataPackName) {
 
-    if (!jobInfo.specificManifestKeys && ! jobInfo.specificManifestObjects) {
+    if (!jobInfo.specificManifestKeys && !jobInfo.specificManifestObjects) {
         return true;
     }
 
@@ -366,7 +365,7 @@ DataPacksBuilder.prototype.isInManifest = function(jobInfo, dataPackType, dataPa
 
     if (jobInfo.specificManifestObjects && 
         jobInfo.specificManifestObjects[dataPackType] && 
-        jobInfo.specificManifestObjects[dataPackType].indexOf(dataPackName) != -1) {
+        jobInfo.specificManifestObjects[dataPackType].indexOf(dataPackName) != -1 ) {
         jobInfo.manifestFound[dataPackKey] = true; 
         return true; 
     }
@@ -398,9 +397,9 @@ DataPacksBuilder.prototype.initializeImportStatus = function(importPath, jobInfo
             var metadataFilename = path.join(dataPackTypeDir, dataPackName, dataPackLabel + '_DataPack.json');
 
             if (dataPackLabel == null || !self.vlocity.datapacksutils.fileExists(metadataFilename)) {
-                return;                
+                return;
             }
-
+                                
             self.loadFilesAtPath(path.join(dataPackTypeDir, dataPackName), jobInfo, dataPackKey);
             var sobjectData = JSON.parse(self.getFileData(metadataFilename));
             var generatedDataPackKey = dataPackType + '/' + self.vlocity.datapacksexpand.getDataPackFolder(dataPackType, sobjectData.VlocityRecordSObjectType, sobjectData);
@@ -502,7 +501,7 @@ DataPacksBuilder.prototype.getNextImport = function(importPath, dataPackKeys, si
                 if (dataPackType.indexOf('SObject_') == 0) {
                     dataPackType = 'SObject';
                 }
-
+                
                 var fileData = self.getFileData(fullPathToFiles, dataPackLabel + '_DataPack.json');
                 
                 if (!fileData) {
@@ -630,13 +629,13 @@ DataPacksBuilder.prototype.getNextImport = function(importPath, dataPackKeys, si
                                 && !(jobInfo.currentStatus[referenceKey] == 'Success' 
                                 || jobInfo.currentStatus[referenceKey] == 'Header')) {
                                 hasReference = true;
-                        }
+                            }
                         }
                     });
 
                     if (hasReference) {
                         continue;
-                }
+                    }
                 }
 
                 nextImport.VlocityDataPackData[sobjectDataField] = dataPackImportBuilt;
@@ -666,7 +665,7 @@ DataPacksBuilder.prototype.getNextImport = function(importPath, dataPackKeys, si
                 VlocityUtils.success('Adding to ' + (jobInfo.singleFile ? 'File' : 'Deploy') + '', nextImport.VlocityDataPackKey + ' - ' + dataPackLabel, jobInfo.headersOnly ? '- Headers Only' : '', jobInfo.forceDeploy ? '- Force Deploy' : '');
 
                 currentDataPackKeysInImport[dataPackKey] = true;
-                
+
                 return nextImport;
             } catch (e) {
                 VlocityUtils.error('Error Formatting Deploy', dataPackKey, e.stack);

--- a/lib/datapacksbuilder.js
+++ b/lib/datapacksbuilder.js
@@ -69,11 +69,11 @@ DataPacksBuilder.prototype.buildImport = function(importPath, jobInfo, typesInAl
         nextImport = self.getNextImport(importPath, Object.keys(jobInfo.currentStatus), jobInfo.singleFile === true, jobInfo, typesInAllImports, currentDataPackKeysInImport,currentTypesInImport, !jobInfo.singleFile ? dataPackImportLength : 0);
 
         if (nextImport) {
+           
+           if (!jobInfo.singleFile && Object.keys(currentDataPackKeysInImport).length > 1 && (stringify(nextImport).length > maxImportSize)) {
 
-            dataPackImportLength += stringify(nextImport).length;
-
-            if (self.needsPagination(nextImport, jobInfo)) {
-                var paginated = self.paginateDataPack(nextImport, jobInfo);
+                if (self.needsPagination(nextImport, jobInfo)) {
+                    var paginated = self.paginateDataPack(nextImport, jobInfo);
 
                 if (paginated.length == 0) {
                     paginated = [ nextImport ];
@@ -89,18 +89,19 @@ DataPacksBuilder.prototype.buildImport = function(importPath, jobInfo, typesInAl
             currentDataPackKeysInImport[nextImport.VlocityDataPackKey] = true;
             currentTypesInImport[nextImport.VlocityDataPackType] = true;
             typesInAllImports[nextImport.VlocityDataPackType] = true;
-            
-            if (!jobInfo.singleFile && (Object.keys(currentDataPackKeysInImport).length == self.vlocity.datapacksutils.getMaxDeploy(nextImport.VlocityDataPackType) || nextImport.shouldBreakImportLoop)) {
-                delete nextImport.shouldBreakImportLoop;
-                break;
+                
+                if (!jobInfo.singleFile && (Object.keys(currentDataPackKeysInImport).length == self.vlocity.datapacksutils.getMaxDeploy(nextImport.VlocityDataPackType) || nextImport.shouldBreakImportLoop)) {
+                    delete nextImport.shouldBreakImportLoop;
+                    break;
+                }
             }
-        } 
     } while (nextImport && (jobInfo.singleFile || (dataPackImportLength < self.maxImportSize && dataPackImport.dataPacks.length < maxImportCount)));
 
     if (dataPackImport.dataPacks.length > 0) {
         VlocityUtils.success('Deploy', dataPackImport.dataPacks.length, 'Items');
-    }
-   
+        }
+    } while (nextImport && (jobInfo.singleFile || (stringify(dataPackImport).length < maxImportSize && dataPackImport.dataPacks.length < maxImportCount)));
+
     self.compileQueuedData(result => {
         if(result.hasErrors && !jobInfo.singleFile) {            
             jobInfo.hasError = true;
@@ -239,26 +240,26 @@ DataPacksBuilder.prototype.countRecords = function(dataPackData) {
 
     var count = 0;
     if (dataPackData) {
-        if (dataPackData.VlocityDataPackData) {
-            var dataPackType = dataPackData.VlocityDataPackType;
+    if (dataPackData.VlocityDataPackData) {
+        var dataPackType = dataPackData.VlocityDataPackType;
 
-            var dataField = self.vlocity.datapacksutils.getDataField(dataPackData);
+        var dataField = self.vlocity.datapacksutils.getDataField(dataPackData);
 
-            if (dataField) {
-                count += self.countRecords(dataPackData.VlocityDataPackData[dataField][0]);
-            }
-        } else { 
-            if (Array.isArray(dataPackData)) {
-                dataPackData.forEach(function(childData) {
-                    count += self.countRecords(childData);
-                });
-            } else if (dataPackData.VlocityDataPackType == 'SObject') {
-                Object.keys(dataPackData).forEach(function(key) {
-                    count += self.countRecords(dataPackData[key]);
-                });
-                count++;
-            }
+        if (dataField) {
+            count += self.countRecords(dataPackData.VlocityDataPackData[dataField][0]);
         }
+    } else { 
+        if (Array.isArray(dataPackData)) {
+            dataPackData.forEach(function(childData) {
+                count += self.countRecords(childData);
+            });
+        } else if (dataPackData.VlocityDataPackType == 'SObject') {
+            Object.keys(dataPackData).forEach(function(key) {
+                count += self.countRecords(dataPackData[key]);
+            });
+            count++;
+        }
+    }
     }
 
     return count;
@@ -346,7 +347,7 @@ DataPacksBuilder.prototype.getDataPackLabel = function(dataPackTypeDir, dataPack
 
 DataPacksBuilder.prototype.isInManifest = function(jobInfo, dataPackType, dataPackKey, dataPackName) {
 
-    if (!jobInfo.specificManifestKeys && !jobInfo.specificManifestObjects) {
+    if (!jobInfo.specificManifestKeys && ! jobInfo.specificManifestObjects) {
         return true;
     }
 
@@ -365,7 +366,7 @@ DataPacksBuilder.prototype.isInManifest = function(jobInfo, dataPackType, dataPa
 
     if (jobInfo.specificManifestObjects && 
         jobInfo.specificManifestObjects[dataPackType] && 
-        jobInfo.specificManifestObjects[dataPackType].indexOf(dataPackName) != -1 ) {
+        jobInfo.specificManifestObjects[dataPackType].indexOf(dataPackName) != -1) {
         jobInfo.manifestFound[dataPackKey] = true; 
         return true; 
     }
@@ -397,9 +398,9 @@ DataPacksBuilder.prototype.initializeImportStatus = function(importPath, jobInfo
             var metadataFilename = path.join(dataPackTypeDir, dataPackName, dataPackLabel + '_DataPack.json');
 
             if (dataPackLabel == null || !self.vlocity.datapacksutils.fileExists(metadataFilename)) {
-                return;
+                return;                
             }
-                                
+
             self.loadFilesAtPath(path.join(dataPackTypeDir, dataPackName), jobInfo, dataPackKey);
             var sobjectData = JSON.parse(self.getFileData(metadataFilename));
             var generatedDataPackKey = dataPackType + '/' + self.vlocity.datapacksexpand.getDataPackFolder(dataPackType, sobjectData.VlocityRecordSObjectType, sobjectData);
@@ -501,7 +502,7 @@ DataPacksBuilder.prototype.getNextImport = function(importPath, dataPackKeys, si
                 if (dataPackType.indexOf('SObject_') == 0) {
                     dataPackType = 'SObject';
                 }
-                
+
                 var fileData = self.getFileData(fullPathToFiles, dataPackLabel + '_DataPack.json');
                 
                 if (!fileData) {
@@ -629,13 +630,13 @@ DataPacksBuilder.prototype.getNextImport = function(importPath, dataPackKeys, si
                                 && !(jobInfo.currentStatus[referenceKey] == 'Success' 
                                 || jobInfo.currentStatus[referenceKey] == 'Header')) {
                                 hasReference = true;
-                            }
+                        }
                         }
                     });
 
                     if (hasReference) {
                         continue;
-                    }
+                }
                 }
 
                 nextImport.VlocityDataPackData[sobjectDataField] = dataPackImportBuilt;
@@ -665,7 +666,7 @@ DataPacksBuilder.prototype.getNextImport = function(importPath, dataPackKeys, si
                 VlocityUtils.success('Adding to ' + (jobInfo.singleFile ? 'File' : 'Deploy') + '', nextImport.VlocityDataPackKey + ' - ' + dataPackLabel, jobInfo.headersOnly ? '- Headers Only' : '', jobInfo.forceDeploy ? '- Force Deploy' : '');
 
                 currentDataPackKeysInImport[dataPackKey] = true;
-
+                
                 return nextImport;
             } catch (e) {
                 VlocityUtils.error('Error Formatting Deploy', dataPackKey, e.stack);

--- a/lib/datapacksutils.js
+++ b/lib/datapacksutils.js
@@ -576,8 +576,7 @@ DataPacksUtils.prototype.runApex = function(projectPath, filePaths, currentConte
             this.splitApex(loadedApex, currentContextData).map(apexChunk =>
                 new Promise((resolve, reject) => 
                     this.vlocity.jsForceConnection.tooling.executeAnonymous(apexChunk, (err, res) => {
-                        if (err) return reject(err);
-                    if (!res || res.success === true) return resolve(true);
+                        if (!res || res.success === true) return resolve(true);
                         if (res.compileProblem) {
                             VlocityUtils.error('APEX Compilation Error', res.compileProblem);
                         } 
@@ -587,7 +586,7 @@ DataPacksUtils.prototype.runApex = function(projectPath, filePaths, currentConte
                         if (res.exceptionStackTrace) {
                             VlocityUtils.error('APEX Exception StackTrace', res.exceptionStackTrace);
                         }
-                        return reject(res.compileProblem || res.exceptionMessage || 'APEX code failed to execute but no exception message was provided');
+                        return reject(err || res.compileProblem || res.exceptionMessage || 'APEX code failed to execute but no exception message was provided');
                     })
                 )
             )

--- a/lib/datapacksutils.js
+++ b/lib/datapacksutils.js
@@ -490,7 +490,7 @@ DataPacksUtils.prototype.isInManifest = function(dataPackData, manifest) {
     return false;
 }
 
-DataPacksUtils.prototype.loadApex = function(projectPath, filePath, currentContextData) {
+DataPacksUtils.prototype.loadApex = function(projectPath, filePath) {
     var possiblePaths = [
         path.join(projectPath, filePath),
         path.join(__dirname, '..', 'apex', filePath)
@@ -505,52 +505,91 @@ DataPacksUtils.prototype.loadApex = function(projectPath, filePath, currentConte
     VlocityUtils.report('Loading Apex', apexFilePath);
 
     var apexFileData = fs.readFileSync(apexFilePath, 'utf8');
-    var includes = apexFileData.match(/\/\/include(.*?);/g);
+    var includes = apexFileData.match(/\/\/include(.*?);/gi);
     var includePromises = [];
 
     if (includes) {
         var srcdir = path.dirname(apexFilePath);
-        for (var i = 0; i < includes.length; i++) {
-            var replacement = includes[i];
-            var className = replacement.replace("//include ", "").replace(";", "");             
+        includes.forEach(replacement => {        
+            var className = replacement.match(/\/\/include(.*?);/i)[1].trim();  
             includePromises.push(
-                this.loadApex(srcdir, className, currentContextData).then(includedFileData => {
-                    return apexFileData.replace(replacement, includedFileData);
+                this.loadApex(srcdir, className).then(includedFileData => {
+                    return {
+                        replacement: replacement,
+                        fileData: includedFileData
+                    };
                 }
             ));         
+        });
+    }
+
+    return Promise.all(includePromises).then(includedClasses => {        
+        includedClasses.forEach(value => {
+            apexFileData = apexFileData.replace(value.replacement, value.fileData);
+        });
+        return apexFileData;
+    });
+};
+
+DataPacksUtils.prototype.splitApex = function(apexFileData, currentContextData) {
+    // This function splits APEX in multiple chuncks so that the can be executed as anon apex
+    // 16,088 is the limit according to a topic on SO
+    const MAX_ANON_APEX_SIZE = 10000; 
+
+    var formatApex = (data, contextData) => data
+        .replace(/CURRENT_DATA_PACKS_CONTEXT_DATA/g, JSON.stringify(contextData))
+        .replace(/%vlocity_namespace%/g, this.vlocity.namespace)
+        .replace(/vlocity_namespace/g, this.vlocity.namespace);
+
+    var fromattedApex = [];
+    var intContextData = [];
+    currentContextData = currentContextData || [];
+   
+    for(var i = 0; i < currentContextData.length; i++) {
+        var isLastItem = (i+1) == currentContextData.length;
+        var apex = formatApex(apexFileData, intContextData.concat(currentContextData[i]));
+        if (isLastItem) {
+            fromattedApex.push(formatApex(apexFileData, intContextData));
+        } else if (apex.length > MAX_ANON_APEX_SIZE) {
+            if (intContextData.length == 0) {
+                throw 'Your APEX is to big to be executed anonymously.';
+            }
+            fromattedApex.push(formatApex(apexFileData, intContextData));
+            intContextData = [];
+            i--; // try agin to fit this context in the next Anon apex chunck
+        } else {
+            intContextData.push(currentContextData[i]);
         }
     }
 
-    return Promise.all(includePromises).then(() => {
-        if (!currentContextData) {
-            currentContextData = [];
-        }
-        return apexFileData
-            .replace(/CURRENT_DATA_PACKS_CONTEXT_DATA/g, JSON.stringify(currentContextData))
-            .replace(/%vlocity_namespace%/g, this.vlocity.namespace)
-            .replace(/vlocity_namespace/g, this.vlocity.namespace);
-    });
-}
+    if (currentContextData.length == 0) {
+        fromattedApex.push(formatApex(apexFileData, currentContextData));
+    }
+
+    return fromattedApex;
+};
 
 DataPacksUtils.prototype.runApex = function(projectPath, filePaths, currentContextData) {
     filePaths = Array.isArray(filePaths) ? filePaths : [ filePaths ];
     return Promise.all(filePaths.map(filePath => 
-        this.loadApex(projectPath, filePath, currentContextData).then(apexFileData => 
-            new Promise((resolve, reject) => 
-                this.vlocity.jsForceConnection.tooling.executeAnonymous(apexFileData, (err, res) => {
-                    if (err) return reject(err);
+        this.loadApex(projectPath, filePath).then(loadedApex => 
+            this.splitApex(loadedApex, currentContextData).map(apexChunk =>
+                new Promise((resolve, reject) => 
+                    this.vlocity.jsForceConnection.tooling.executeAnonymous(apexChunk, (err, res) => {
+                        if (err) return reject(err);
                     if (!res || res.success === true) return resolve(true);
-                    if (res.compileProblem) {
-                        VlocityUtils.error('APEX Compilation Error', res.compileProblem);
-                    } 
-                    if (res.exceptionMessage) {
-                        VlocityUtils.error('APEX Exception Message', res.exceptionMessage);
-                    }
-                    if (res.exceptionStackTrace) {
-                        VlocityUtils.error('APEX Exception StackTrace', res.exceptionStackTrace);
-                    }
-                    return reject(res.compileProblem || res.exceptionMessage || 'APEX code failed to execute but no exception message was provided');
-                })
+                        if (res.compileProblem) {
+                            VlocityUtils.error('APEX Compilation Error', res.compileProblem);
+                        } 
+                        if (res.exceptionMessage) {
+                            VlocityUtils.error('APEX Exception Message', res.exceptionMessage);
+                        }
+                        if (res.exceptionStackTrace) {
+                            VlocityUtils.error('APEX Exception StackTrace', res.exceptionStackTrace);
+                        }
+                        return reject(res.compileProblem || res.exceptionMessage || 'APEX code failed to execute but no exception message was provided');
+                    })
+                )
             )
         )
     ));

--- a/lib/datapacksutils.js
+++ b/lib/datapacksutils.js
@@ -491,67 +491,54 @@ DataPacksUtils.prototype.isInManifest = function(dataPackData, manifest) {
 }
 
 DataPacksUtils.prototype.loadApex = function(projectPath, filePath, currentContextData) {
-    var self = this;
+    var possiblePaths = [
+        path.join(projectPath, filePath),
+        path.join(__dirname, '..', 'apex', filePath)
+    ];
+    var apexFilePath = possiblePaths.find(apexFilePath => 
+        this.vlocity.datapacksutils.fileExists(apexFilePath));
 
-    var defaultApexPath = path.join(__dirname, '..', 'apex', filePath);
-   
-    if (this.vlocity.datapacksutils.fileExists(projectPath + '/' + filePath)) {
-        VlocityUtils.report('Loading Apex', projectPath + '/' + filePath);
-        var apexFileName = projectPath + '/' + filePath;
-    } else if (this.vlocity.datapacksutils.fileExists(defaultApexPath)) {
-        VlocityUtils.report('Loading Apex',  defaultApexPath);
-        var apexFileName = defaultApexPath;
-    } else {
+    if (!apexFilePath) {
         return Promise.reject('The specified file \'' + filePath + '\' does not exist.');
     }
 
-    if (apexFileName) {
-        var apexFileData = fs.readFileSync(apexFileName, 'utf8');
-        var includes = apexFileData.match(/\/\/include(.*?);/g);
-        var includePromises = [];
+    VlocityUtils.report('Loading Apex', apexFilePath);
 
-        if (includes) {
-            var srcdir = path.dirname(apexFileName);
-            for (var i = 0; i < includes.length; i++) {
-                var replacement = includes[i];
-                var className = replacement.replace("//include ", "").replace(";", "");             
-                includePromises.push(
-                    this.loadApex(srcdir, className, currentContextData).then((includedFileData) => {
-                        apexFileData = apexFileData.replace(replacement, includedFileData);
-                        return apexFileData;
-                    }
-                ));         
-            }
+    var apexFileData = fs.readFileSync(apexFilePath, 'utf8');
+    var includes = apexFileData.match(/\/\/include(.*?);/g);
+    var includePromises = [];
+
+    if (includes) {
+        var srcdir = path.dirname(apexFilePath);
+        for (var i = 0; i < includes.length; i++) {
+            var replacement = includes[i];
+            var className = replacement.replace("//include ", "").replace(";", "");             
+            includePromises.push(
+                this.loadApex(srcdir, className, currentContextData).then(includedFileData => {
+                    return apexFileData.replace(replacement, includedFileData);
+                }
+            ));         
         }
-
-        return Promise.all(includePromises).then(() => {
-
-            if (!currentContextData) {
-                currentContextData = [];
-            }
-
-            apexFileData = apexFileData.replace(/CURRENT_DATA_PACKS_CONTEXT_DATA/g, JSON.stringify(currentContextData));
-            
-            return apexFileData
-                .replace(/%vlocity_namespace%/g, this.vlocity.namespace)
-                .replace(/vlocity_namespace/g, this.vlocity.namespace);
-        });
-    } else {
-        return Promise.reject('ProjectPath or filePath arguments passed as null or undefined.');        
     }
+
+    return Promise.all(includePromises).then(() => {
+        if (!currentContextData) {
+            currentContextData = [];
+        }
+        return apexFileData
+            .replace(/CURRENT_DATA_PACKS_CONTEXT_DATA/g, JSON.stringify(currentContextData))
+            .replace(/%vlocity_namespace%/g, this.vlocity.namespace)
+            .replace(/vlocity_namespace/g, this.vlocity.namespace);
+    });
 }
 
-DataPacksUtils.prototype.runApex = function(projectPath, filePath, currentContextData) {
-    var self = this;
-
-    return this
-        .loadApex(projectPath, filePath, currentContextData)
-        .then((apexFileData) => { 
-            return new Promise((resolve, reject) => {
-                self.vlocity.jsForceConnection.tooling.executeAnonymous(apexFileData, (err, res) => {
-
+DataPacksUtils.prototype.runApex = function(projectPath, filePaths, currentContextData) {
+    filePaths = Array.isArray(filePaths) ? filePaths : [ filePaths ];
+    return Promise.all(filePaths.map(filePath => 
+        this.loadApex(projectPath, filePath, currentContextData).then(apexFileData => 
+            new Promise((resolve, reject) => 
+                this.vlocity.jsForceConnection.tooling.executeAnonymous(apexFileData, (err, res) => {
                     if (err) return reject(err);
-
                     if (!res || res.success === true) return resolve(true);
                     if (res.compileProblem) {
                         VlocityUtils.error('APEX Compilation Error', res.compileProblem);
@@ -562,11 +549,11 @@ DataPacksUtils.prototype.runApex = function(projectPath, filePath, currentContex
                     if (res.exceptionStackTrace) {
                         VlocityUtils.error('APEX Exception StackTrace', res.exceptionStackTrace);
                     }
-
                     return reject(res.compileProblem || res.exceptionMessage || 'APEX code failed to execute but no exception message was provided');
-                });
-            });
-        });
+                })
+            )
+        )
+    ));
 };
 
 DataPacksUtils.prototype.runJavaScript = function(projectPath, filePath, currentContextData, jobInfo, callback) {
@@ -677,7 +664,7 @@ DataPacksUtils.prototype.getDisplayName = function(dataPack) {
                 name += ' ';
             }
 
-            name += dataPack[field];
+            name += dataPack[field] ;
         }
     });
 
@@ -755,7 +742,7 @@ DataPacksUtils.prototype.printJobStatus = function(jobInfo) {
     if (!jobInfo.currentStatus) {
         return;
     }
-    
+
     var statusCount = { Remaining: 0, Success: 0, Error: 0 };
     var statusReportFunc = {
         Success: VlocityUtils.success,
@@ -780,7 +767,7 @@ DataPacksUtils.prototype.printJobStatus = function(jobInfo) {
         statusCount[status] = (statusCount[status] || 0) + 1;
         keysByStatus[status] = keysByStatus[status] || {};
 
-        // For Exports        
+        // For Exports
         var keyForStatus = jobInfo.vlocityKeysToNewNamesMap[dataPackKey] ? jobInfo.vlocityKeysToNewNamesMap[dataPackKey] : dataPackKey;
 
         if (keyForStatus.indexOf('/') != -1) {
@@ -817,7 +804,7 @@ DataPacksUtils.prototype.printJobStatus = function(jobInfo) {
     }
 
     var elapsedTime = (Date.now() - jobInfo.startTime) / 1000;
-    
+
     if (jobInfo.headersOnly) {
         VlocityUtils.report('Uploading Only Parent Objects');
     }
@@ -829,7 +816,7 @@ DataPacksUtils.prototype.printJobStatus = function(jobInfo) {
     if (this.vlocity.username) {
         VlocityUtils.report('Salesforce Org', this.vlocity.username);
     }
-
+    
     VlocityUtils.report('Version Info', 'v'+VLOCITY_BUILD_VERSION, this.vlocity.namespace, this.vlocity.PackageVersion);
     VlocityUtils.verbose('Log File', path.join('vlocity-temp', 'logs', jobInfo.logName));
     

--- a/lib/vlocitycli.js
+++ b/lib/vlocitycli.js
@@ -307,16 +307,18 @@ VlocityCLI.prototype.runCLI = function(commands, success, error) {
 
     try {
         if (jobName && !dataPacksJobsData[jobName]) {
-            // Allow to just specify file / filepath
-            if (fs.existsSync(jobName)) {
-                dataPacksJobsData[jobName] = yaml.safeLoad(fs.readFileSync(jobName, 'utf8'));
-            } else if (fs.existsSync(dataPacksJobFolder + '/' + jobName)) {
-                dataPacksJobsData[jobName] = yaml.safeLoad(fs.readFileSync(dataPacksJobFolder + '/' + jobName, 'utf8'));
-            } else if (fs.existsSync(dataPacksJobFolder + '/' + jobName + '.yaml')) {
-                dataPacksJobsData[jobName] = yaml.safeLoad(fs.readFileSync(dataPacksJobFolder + '/' + jobName + '.yaml', 'utf8'));
-            } else {
+            var searchFolders = [
+                '.',
+                path.resolve(dataPacksJobFolder),
+                path.resolve(__dirname, '..', dataPacksJobFolder)
+            ];
+            var jobfileName = searchFolders
+                .map(folderName => path.join(folderName, jobName + '.yaml'))
+                .find(fileName => fs.existsSync(fileName));
+            if (!jobfileName) {
                 return error(self.formatResponseCLI({ message: jobName + ' Not Found' }));
-            }
+            }            
+            dataPacksJobsData[jobName] = yaml.safeLoad(fs.readFileSync(jobfileName, 'utf8'));
         }
     } catch (e) {
         VlocityUtils.log('Error Loading Job: ' + e.message);


### PR DESCRIPTION
This changes adds for support loading multiple APEX files as pre- and post-deployment job by specifying them in array syntax in the job yaml file:
```yaml
preJobApex:
  Deploy: 
   - apex/RemoveHandsetBundleCategory.cls
   - apex/RemoveVlocityActions.cls
  
postJobApex:
  Deploy: apex/PostDeployJob.cls
```

Also this pull request changes the way that the tools search for job files, using a array of possible folders to search for job files. This makes it easier to add new search directories in the future.