### PR TITLE
fixes for check stale objects

### DIFF
--- a/lib/datapacksjob.js
+++ b/lib/datapacksjob.js
@@ -775,6 +775,7 @@ DataPacksJob.prototype.runDeltaCheck = async function(jobInfo) {
 };
 
 DataPacksJob.prototype.runCheckStaleObjects = async function(jobInfo) {
+    jobInfo.checkStaleObjects = true;
     await this.deltaCheck('CheckStaleObjects', jobInfo);
 };
 

--- a/lib/deltacheck.js
+++ b/lib/deltacheck.js
@@ -447,10 +447,13 @@ DeltaCheck.prototype.processDataPack = async function(dataPackData, vlocityDataP
 
             if (!this.metadataCheckInfo[objectType]) {
                 var fieldName = dataPackData[deltaMetadata.FieldApiName];
-                this.metadataCheckInfo[objectType] = { fieldName : fieldName, vlocityDataPackKey : []};
+                
+                if (fieldName) {
+                    this.metadataCheckInfo[objectType] = { fieldName : fieldName, vlocityDataPackKey : []};
+                    this.metadataCheckInfo[objectType].vlocityDataPackKey.push(vlocityDataPackKey);
+                }
             }
 
-            this.metadataCheckInfo[objectType].vlocityDataPackKey.push(vlocityDataPackKey);
             return;
         }
     }
@@ -458,10 +461,14 @@ DeltaCheck.prototype.processDataPack = async function(dataPackData, vlocityDataP
     if (this.jobInfo.CheckStaleObjects) {
 
         var errorFound = false;
-
+        
         if (vlocityDataPackType === 'SObject') {
             var vlocityRecordSourceKey = dataPackData.VlocityRecordSourceKey;
             this.deltaCheckJobInfo.recordSourceKeyToDataPackKey[vlocityRecordSourceKey] = vlocityDataPackKey;
+
+            if (!this.jobInfo.deltaCheckResults[vlocityDataPackKey]) {
+                this.jobInfo.deltaCheckResults[vlocityDataPackKey] = { status: 'Ready' };
+            }
         } else if (vlocityLookupRecordSourceKey) {
 
             var matchingKeys = this.vlocityMatchingKeys[sObjectType];


### PR DESCRIPTION
record type failed because if statement check checkstaleobject jobinfo is undefined, mark as ready instead when status is unknown