### PR TITLE
BTCA-319 : Support Export and Deploy in Non-Namespaced Orgs

### DIFF
--- a/lib/datapacksexpand.js
+++ b/lib/datapacksexpand.js
@@ -60,8 +60,6 @@ DataPacksExpand.prototype.getNameWithFields = function(nameFields, dataPackData)
         if(dataPackData && !dataPackData[key]){
             if(key.includes('%vlocity_namespace%__')){
                 key = key.replace(/%vlocity_namespace%__/g,'');
-            } else{
-                key = '%vlocity_namespace%__' + key; 
             }
         }
         // If key references a field adds that otherwise is literal string

--- a/lib/datapacksexpand.js
+++ b/lib/datapacksexpand.js
@@ -57,6 +57,13 @@ DataPacksExpand.prototype.generateFilepath = function(dataPackType, parentName, 
 DataPacksExpand.prototype.getNameWithFields = function(nameFields, dataPackData) {
     var self = this;
     var processedNames = (nameFields || []).map(function(key) {
+        if(dataPackData && !dataPackData[key]){
+            if(key.includes('%vlocity_namespace%__')){
+                key = key.replace(/%vlocity_namespace%__/g,'');
+            } else{
+                key = '%vlocity_namespace%__' + key; 
+            }
+        }
         // If key references a field adds that otherwise is literal string
         if (key.indexOf('_') == 0) {
             return key.substring(1);
@@ -91,7 +98,7 @@ DataPacksExpand.prototype.getListFileName = function(dataPackType, sObjectType, 
 
 DataPacksExpand.prototype.getDataPackFolder = function(dataPackType, sObjectType, dataPackData) {
     return this.getNameWithFields(this.vlocity.datapacksutils.getFolderName(dataPackType, sObjectType), dataPackData);
-};
+}; 
 
 DataPacksExpand.prototype.buildHierarchyKey = function(listDataBySourceKey, sortFields, listRec, depth) {
     var self = this;
@@ -100,7 +107,10 @@ DataPacksExpand.prototype.buildHierarchyKey = function(listDataBySourceKey, sort
         
         var parentField = sortFields[1];
         var keyField = sortFields[2];
-
+        if(!self.vlocity.namespace){
+            parentField = parentField.replace(/%vlocity_namespace%__/g,'');
+            keyField = keyField.replace(/%vlocity_namespace%__/g,'');
+        }
         var thisKey = listRec[keyField].toString().padStart(10, '0');
 
         if (!listRec[parentField]) {
@@ -552,7 +562,9 @@ DataPacksExpand.prototype.preprocessSObjects = async function(currentData, dataP
                             try {
                                 var splitFields = reference.Field.split('.');
                                 var primaryField = splitFields.shift();
-
+                                if(!self.vlocity.namespace){
+                                    primaryField = primaryField.replace(/%vlocity_namespace%__/g,'')
+                                }
                                 if (currentData[primaryField]) {
                                     self.getNestedDataPackReferences(jobInfo, JSON.parse(currentData[primaryField]), parentKeys, splitFields.join('.'), reference.Type);
                                 }

--- a/lib/datapacksjob.js
+++ b/lib/datapacksjob.js
@@ -64,7 +64,11 @@ DataPacksJob.prototype.runJob = async function(action, jobData) {
         if (jobInfo.queries) {
             for (var i = 0; i < jobInfo.queries.length; i++) {
                 if (typeof jobInfo.queries[i] === 'string') {
-                    jobInfo.queries[i] = this.queryDefinitions[jobInfo.queries[i]];
+                    let queryObj = this.queryDefinitions[jobInfo.queries[i]];
+                    if(!this.vlocity.namespace && queryObj.query.includes('%vlocity_namespace%__')){
+                        queryObj.query = queryObj.query.replace(/%vlocity_namespace%__/g,'');
+                    }
+                    jobInfo.queries[i] = queryObj;
                 }
             }
         }
@@ -559,7 +563,11 @@ DataPacksJob.prototype.formatResponse = async function(jobInfo, error) {
             }
 
             if (response.message) {
-                response.message = response.message.replace(/%vlocity_namespace%/g, this.vlocity.namespace);
+                if(this.vlocity.namespace){
+                    response.message = response.message.replace(/%vlocity_namespace%/g, this.vlocity.namespace);
+                } else{
+                    response.message = response.message.replace(/%vlocity_namespace%__/g, '');
+                }
             }
         }
 
@@ -647,9 +655,11 @@ DataPacksJob.prototype.runQueryForManifest = async function(queryInput) {
     try {
         var thisQuery = await this.vlocity.jsForceConnection.query(query)
         .on("record", (record) => {
-
-            record = JSON.parse(JSON.stringify(record).replace(new RegExp(this.vlocity.namespace, 'g'), '%vlocity_namespace%'));
-
+            if(this.vlocity.namespace){
+                record = JSON.parse(JSON.stringify(record).replace(new RegExp(this.vlocity.namespace, 'g'), '%vlocity_namespace%'));
+            } else {
+                record = JSON.parse(JSON.stringify(record));
+            }
             record.VlocityDataPackType = queryData.VlocityDataPackType;
             record.VlocityRecordSObjectType = record.attributes.type;
 
@@ -1545,7 +1555,12 @@ DataPacksJob.prototype.updateSettings = async function(jobInfo) {
     });
 
     let hashCode = this.vlocity.datapacksutils.hashCode(stringify(dataJson));
-    var query = `Select ${this.vlocity.namespace}__MapId__c from ${this.vlocity.namespace}__DRMapItem__c where ${this.vlocity.namespace}__MapId__c = '${hashCode}'`;
+    var query = '';
+    if(this.vlocity.namespace){
+        query = `Select ${this.vlocity.namespace}__MapId__c from ${this.vlocity.namespace}__DRMapItem__c where ${this.vlocity.namespace}__MapId__c = '${hashCode}'`;
+    } else{
+        query = `Select MapId__c from DRMapItem__c where MapId__c = '${hashCode}'`;
+    }
     
     VlocityUtils.verbose('Get Existing Setting', query);
 
@@ -1576,15 +1591,28 @@ DataPacksJob.prototype.updateSettings = async function(jobInfo) {
 
         var settingsRecord = {};
         settingsRecord.Name = 'DataRaptor Migration';
-        settingsRecord[`${this.vlocity.namespace}__DomainObjectAPIName__c`] = 'JSON';
-        settingsRecord[`${this.vlocity.namespace}__DomainObjectFieldAPIName__c`] = 'JSON';
-        settingsRecord[`${this.vlocity.namespace}__InterfaceFieldAPIName__c`] = 'JSON';
-        settingsRecord[`${this.vlocity.namespace}__DomainObjectCreationOrder__c`] = '0';
-        settingsRecord[`${this.vlocity.namespace}__MapId__c`] = `${hashCode}`;
-        settingsRecord[`${this.vlocity.namespace}__IsDisabled__c`] = true;
+        if(this.vlocity.namespace){
+            settingsRecord[`${this.vlocity.namespace}__DomainObjectAPIName__c`] = 'JSON';
+            settingsRecord[`${this.vlocity.namespace}__DomainObjectFieldAPIName__c`] = 'JSON';
+            settingsRecord[`${this.vlocity.namespace}__InterfaceFieldAPIName__c`] = 'JSON';
+            settingsRecord[`${this.vlocity.namespace}__DomainObjectCreationOrder__c`] = '0';
+            settingsRecord[`${this.vlocity.namespace}__MapId__c`] = `${hashCode}`;
+            settingsRecord[`${this.vlocity.namespace}__IsDisabled__c`] = true;
+        } else{
+            settingsRecord[`DomainObjectAPIName__c`] = 'JSON';
+            settingsRecord[`DomainObjectFieldAPIName__c`] = 'JSON';
+            settingsRecord[`InterfaceFieldAPIName__c`] = 'JSON';
+            settingsRecord[`DomainObjectCreationOrder__c`] = '0';
+            settingsRecord[`MapId__c`] = `${hashCode}`;
+            settingsRecord[`IsDisabled__c`] = true;
+        }
         
-        let settingsRecordResult = await this.vlocity.jsForceConnection.sobject(`${this.vlocity.namespace}__DRMapItem__c`).upsert([settingsRecord],`${this.vlocity.namespace}__MapId__c`, { allOrNone: true });
-
+        let settingsRecordResult = '';
+        if(this.vlocity.namespace){
+            settingsRecordResult = await this.vlocity.jsForceConnection.sobject(`${this.vlocity.namespace}__DRMapItem__c`).upsert([settingsRecord],`${this.vlocity.namespace}__MapId__c`, { allOrNone: true });
+        } else{
+            settingsRecordResult = await this.vlocity.jsForceConnection.sobject(`DRMapItem__c`).upsert([settingsRecord],`MapId__c`, { allOrNone: true });
+        }
         VlocityUtils.verbose(settingsRecordResult);
         VlocityUtils.milestone('Settings Updated');
     } else {
@@ -1872,6 +1900,9 @@ DataPacksJob.prototype.deployBulkRecords = async function (dataPack, BulkRecords
             if (typeof records[key] === 'object') {
                 if (records[key].hasOwnProperty('VlocityMatchingRecordSourceKey')) {
                     var salesforceIdMapKey = records[key].VlocityMatchingRecordSourceKey;
+                    if(!this.vlocity.namespace){
+                        salesforceIdMapKey = salesforceIdMapKey.replace(/%vlocity_namespace%__/g,'');
+                    }
                     records[key] = self.vlocity.salesforceIdMap[salesforceIdMapKey];
                 }
             }
@@ -1887,11 +1918,11 @@ DataPacksJob.prototype.deployBulkRecords = async function (dataPack, BulkRecords
         //TBD Also add missing fields to the BulkRecords since bulk api expects all the fields of custom_object in the data
     }
     // replace namespace in the BulkRecords fields
-    if (!self.vlocity.namespace) {
-        BulkRecords = JSON.parse(JSON.stringify(BulkRecords).replace(/%vlocity_namespace%__/g, ''));
+    if (self.vlocity.namespace) {
+        BulkRecords = JSON.parse(JSON.stringify(BulkRecords).replace(/%vlocity_namespace%__/g, self.vlocity.namespacePrefix));
     }
     else {
-        BulkRecords = JSON.parse(JSON.stringify(BulkRecords).replace(/%vlocity_namespace%__/g, self.vlocity.namespacePrefix));
+        BulkRecords = JSON.parse(JSON.stringify(BulkRecords).replace(/%vlocity_namespace%__/g, ''));
     }
 
     var result = await self.vlocity.datapacksutils.createBulkJob(objectName, 'insert', BulkRecords, randomNum);
@@ -1899,7 +1930,7 @@ DataPacksJob.prototype.deployBulkRecords = async function (dataPack, BulkRecords
     if (result == 'Batch Upload Error') {
         jobInfo.currentStatus[dataPack.VlocityDataPackKey] = 'Error';
         jobInfo.hasError = true;
-        jobInfo.errors.push('Bulk Job Error ' + dataPack.VlocityDataPackKey + ' ' + e);
+        jobInfo.errors.push('Bulk Job Error ' + dataPack.VlocityDataPackKey);
     }
 }
 

--- a/lib/datapacksjob.js
+++ b/lib/datapacksjob.js
@@ -1555,12 +1555,8 @@ DataPacksJob.prototype.updateSettings = async function(jobInfo) {
     });
 
     let hashCode = this.vlocity.datapacksutils.hashCode(stringify(dataJson));
-    var query = '';
-    if(this.vlocity.namespace){
-        query = `Select ${this.vlocity.namespace}__MapId__c from ${this.vlocity.namespace}__DRMapItem__c where ${this.vlocity.namespace}__MapId__c = '${hashCode}'`;
-    } else{
-        query = `Select MapId__c from DRMapItem__c where MapId__c = '${hashCode}'`;
-    }
+
+    var query = `Select ${this.vlocity.namespacePrefix}MapId__c from ${this.vlocity.namespacePrefix}DRMapItem__c where ${this.vlocity.namespacePrefix}MapId__c = '${hashCode}'`;
     
     VlocityUtils.verbose('Get Existing Setting', query);
 
@@ -1591,28 +1587,15 @@ DataPacksJob.prototype.updateSettings = async function(jobInfo) {
 
         var settingsRecord = {};
         settingsRecord.Name = 'DataRaptor Migration';
-        if(this.vlocity.namespace){
-            settingsRecord[`${this.vlocity.namespace}__DomainObjectAPIName__c`] = 'JSON';
-            settingsRecord[`${this.vlocity.namespace}__DomainObjectFieldAPIName__c`] = 'JSON';
-            settingsRecord[`${this.vlocity.namespace}__InterfaceFieldAPIName__c`] = 'JSON';
-            settingsRecord[`${this.vlocity.namespace}__DomainObjectCreationOrder__c`] = '0';
-            settingsRecord[`${this.vlocity.namespace}__MapId__c`] = `${hashCode}`;
-            settingsRecord[`${this.vlocity.namespace}__IsDisabled__c`] = true;
-        } else{
-            settingsRecord[`DomainObjectAPIName__c`] = 'JSON';
-            settingsRecord[`DomainObjectFieldAPIName__c`] = 'JSON';
-            settingsRecord[`InterfaceFieldAPIName__c`] = 'JSON';
-            settingsRecord[`DomainObjectCreationOrder__c`] = '0';
-            settingsRecord[`MapId__c`] = `${hashCode}`;
-            settingsRecord[`IsDisabled__c`] = true;
-        }
+        settingsRecord[`${this.vlocity.namespacePrefix}DomainObjectAPIName__c`] = 'JSON';
+        settingsRecord[`${this.vlocity.namespacePrefix}DomainObjectFieldAPIName__c`] = 'JSON';
+        settingsRecord[`${this.vlocity.namespacePrefix}InterfaceFieldAPIName__c`] = 'JSON';
+        settingsRecord[`${this.vlocity.namespacePrefix}DomainObjectCreationOrder__c`] = '0';
+        settingsRecord[`${this.vlocity.namespacePrefix}MapId__c`] = `${hashCode}`;
+        settingsRecord[`${this.vlocity.namespacePrefix}IsDisabled__c`] = true;
         
-        let settingsRecordResult = '';
-        if(this.vlocity.namespace){
-            settingsRecordResult = await this.vlocity.jsForceConnection.sobject(`${this.vlocity.namespace}__DRMapItem__c`).upsert([settingsRecord],`${this.vlocity.namespace}__MapId__c`, { allOrNone: true });
-        } else{
-            settingsRecordResult = await this.vlocity.jsForceConnection.sobject(`DRMapItem__c`).upsert([settingsRecord],`MapId__c`, { allOrNone: true });
-        }
+        let settingsRecordResult = await this.vlocity.jsForceConnection.sobject(`${this.vlocity.namespacePrefix}DRMapItem__c`).upsert([settingsRecord],`${this.vlocity.namespacePrefix}MapId__c`, { allOrNone: true });
+    
         VlocityUtils.verbose(settingsRecordResult);
         VlocityUtils.milestone('Settings Updated');
     } else {

--- a/lib/datapacksutils.js
+++ b/lib/datapacksutils.js
@@ -409,9 +409,12 @@ DataPacksUtils.prototype.getExpandedDefinition = function(dataPackType, SObjectT
             definitionValue = this.overrideExpandedDefinitions.SObjects[SObjectType][dataKey];
         }
     }
-
-    if (SObjectType) {
-        SObjectType = SObjectType.replace(this.vlocity.namespace, '%vlocity_namespace%');
+    if(SObjectType){
+        if(!this.vlocity.namespace && SObjectType.indexOf('%vlocity_namespace%__') !== 0){
+            SObjectType = '%vlocity_namespace%__' + SObjectType ;
+        } else{
+            SObjectType = SObjectType.replace(this.vlocity.namespace, '%vlocity_namespace%');
+        }
     }
 
     if (definitionValue === undefined) {
@@ -744,10 +747,18 @@ DataPacksUtils.prototype.splitApex = function(apexFileData, currentContextData) 
     // 16,088 is the limit according to a topic on SO
     const MAX_ANON_APEX_SIZE = 10000; 
 
-    var formatApex = (data, contextData) => data
-        .replace(/CURRENT_DATA_PACKS_CONTEXT_DATA/g, JSON.stringify(contextData))
-        .replace(/%vlocity_namespace%/g, this.vlocity.namespace)
-        .replace(/vlocity_namespace/g, this.vlocity.namespace);
+    var formatApex = (data, contextData) => {
+        data = data.replace(/CURRENT_DATA_PACKS_CONTEXT_DATA/g, JSON.stringify(contextData))
+        if(this.vlocity.namespace){
+            data = data.replace(/%vlocity_namespace%/g, this.vlocity.namespace)
+                    .replace(/vlocity_namespace/g, this.vlocity.namespace);
+        } else{
+            data = data.replace(/%vlocity_namespace%__/g, '')
+                    .replace(/vlocity_namespace__/g, '')
+                    .replace(/vlocity_namespace./g, '');
+        }
+        return data;
+    }
 
     var formattedApex = [];
     var intContextData = [];
@@ -1092,6 +1103,9 @@ DataPacksUtils.prototype.getDisplayName = function(dataPack) {
     }
 
     self.getExpandedDefinition(dataPackType, dataPack.VlocityRecordSObjectType, 'DisplayName').forEach(function(field) {
+        if(!self.vlocity.namespace){
+            field = field.replace(new RegExp('%vlocity_namespace%__', 'g'), '');
+        }
         if (dataPack[field]) {
             if (name) {
                 name += '_';
@@ -2203,7 +2217,7 @@ DataPacksUtils.prototype.printJobStatus = function(jobInfo, forceWrite) {
         VlocityUtils.report('Salesforce Org', this.vlocity.username);
     }
     
-    VlocityUtils.report('Version Info', 'v'+VLOCITY_BUILD_VERSION, this.vlocity.namespace, this.vlocity.PackageVersion ? this.vlocity.PackageVersion : '');
+    VlocityUtils.report('Version Info', 'v'+VLOCITY_BUILD_VERSION, this.vlocity.namespace ? this.vlocity.namespace : '', this.vlocity.PackageVersion ? this.vlocity.PackageVersion : '');
     VlocityUtils.verbose('Log File', path.join(this.vlocity.tempFolder, 'logs', jobInfo.logName));
     
     if (jobInfo.forceDeploy) {

--- a/lib/utilityservice.js
+++ b/lib/utilityservice.js
@@ -21,7 +21,15 @@ UtilityService.prototype.replaceAll = function(str, find, replace) {
 };
 
 UtilityService.prototype.setNamespaceToOrg = function(value) {
-    return JSON.parse(JSON.stringify(value).replace(new RegExp(VLOCITY_NAMESPACE, 'g'), this.vlocity.namespace));
+    if(this.vlocity.namespace){
+        if(JSON.stringify(value).includes(VLOCITY_NAMESPACE+'__')){
+            return JSON.parse(JSON.stringify(value).replace(new RegExp(VLOCITY_NAMESPACE, 'g'), this.vlocity.namespace));
+        } else{
+            return JSON.parse(JSON.stringify(this.vlocity.namespace + '__' + value));
+        }
+    } else{
+        return JSON.parse(JSON.stringify(value).replace(new RegExp(VLOCITY_NAMESPACE+'__', 'g'), ''));
+    }
 };
 
 UtilityService.prototype.setNamespaceToDefault = function(value) {
@@ -32,7 +40,7 @@ UtilityService.prototype.setNamespaceToDefault = function(value) {
         return JSON.parse(JSON.stringify(value).replace(new RegExp(this.vlocity.namespace, 'g'), VLOCITY_NAMESPACE));
     }
     else {
-        return this.vlocity.namespace;
+        return JSON.parse(JSON.stringify(value));
     }
 };
 
@@ -155,8 +163,11 @@ UtilityService.prototype.getDRMatchingKeys = async function() {
         var records = this.setNamespaceToDefault(queryResult.records);
 
         for (var i = 0; i < records.length; i++) {
-            var fieldName = records[i]['%vlocity_namespace%__ObjectAPIName__c'];
-
+            if(this.vlocity.namespace){
+                var fieldName = records[i]['%vlocity_namespace%__ObjectAPIName__c'];
+            } else{
+                var fieldName = records[i]['ObjectAPIName__c'];
+            }
             if (resultMap[fieldName]) {
                 if (records[i]['NamespacePrefix'] !== null) {
                     continue;
@@ -174,9 +185,12 @@ UtilityService.prototype.getDRMatchingKeyFields = async function() {
     var result = await this.getDRMatchingKeys();
 
     for (var objectName in result) {
-        result[objectName] = result[objectName]['%vlocity_namespace%__MatchingKeyFields__c'].split(',');
+        if(this.vlocity.namespace){
+            result[objectName] = result[objectName]['%vlocity_namespace%__MatchingKeyFields__c'].split(',');
+        } else{
+            result[objectName] = result[objectName]['MatchingKeyFields__c'].split(',');
+        }
     }
-
     return result;
 };
 
@@ -373,10 +387,6 @@ UtilityService.prototype.getNamespace = async function() {
         if (!this.vlocity.namespace && this.vlocity.passedInNamespace) {
             this.vlocity.namespace = this.vlocity.passedInNamespace;
         }
-
-        if (this.vlocity.namespace == null) {
-            throw `Vlocity Managed Package Not Found in Org: ${this.vlocity.username}`;
-        } 
         
         VlocityUtils.namespace = this.vlocity.namespace;
 


### PR DESCRIPTION
When a Dev Org has the Vlocity Code but does not have a Namespace the Vlocity Build Tool should still be able to export and deploy the data.