### PR TITLE
Fix query definition for ContentVersion object

### DIFF
--- a/lib/querydefinition.yaml
+++ b/lib/querydefinition.yaml
@@ -19,7 +19,7 @@ Catalog:
   query: Select Id, Name from %vlocity_namespace%__Catalog__c     
 ContentVersion:
   VlocityDataPackType: ContentVersion
-  query: Select Id, Name, Title, %vlocity_namespace%__GlobalKey__c from ContentVersion where %vlocity_namespace%__GlobalKey__c != null
+  query: Select Id, Title, %vlocity_namespace%__GlobalKey__c from ContentVersion where %vlocity_namespace%__GlobalKey__c != null
   manifestOnly: true
 ContextAction:
   VlocityDataPackType: ContextAction


### PR DESCRIPTION
`ContentVersion` objects do not have a `Name `field` and only have a title, removed the name field from  the query definition to fix query errors when exporting just ContentVersion objects.