### PR TITLE
Fix duplicate parameter for DataPacksBuilder.setFileData

### DIFF
--- a/lib/datapacksbuilder.js
+++ b/lib/datapacksbuilder.js
@@ -347,7 +347,7 @@ DataPacksBuilder.prototype.getFileData = function() {
     return this.allFileDataMap[path.normalize(pathString).toLowerCase()];
 }
 
-DataPacksBuilder.prototype.setFileData = async function(filePath, filePath, encoding) {
+DataPacksBuilder.prototype.setFileData = async function(filePath, encoding) {
     var data = await fs.readFile(filePath, encoding);
 
     if (!this.allFileDataMap) {
@@ -387,7 +387,7 @@ DataPacksBuilder.prototype.loadFilesAtPath = async function(srcpath, jobInfo, da
             encoding = 'utf8';
         }
         var filemapkey = path.normalize(path.join(srcpath, filename));
-        filePromises.push(this.setFileData(filemapkey, filemapkey, encoding));
+        filePromises.push(this.setFileData(filemapkey, encoding));
     }
 
     if (filePromises.length > 0) {

--- a/lib/datapacktypes/attributecategory.js
+++ b/lib/datapacktypes/attributecategory.js
@@ -54,5 +54,5 @@ AttributeCategory.prototype.handleAttributeCategoryDisplaySequence = async funct
     var jobInfoCopy = JSON.parse(JSON.stringify(jobInfo));
 
     await this.vlocity.datapacksexpand.expand(jobInfoCopy.projectPath + '/' + jobInfoCopy.expansionPath, {dataPacks: [dataPackWithError]}, jobInfoCopy);
-    await this.vlocity.datapacksbuilder.setFileData(filePath, filePath, "utf8");
+    await this.vlocity.datapacksbuilder.setFileData(filePath, "utf8");
 };


### PR DESCRIPTION
The DataPacksBuilder setFileData method signature is as follows `async function(filePath, filePath, encoding)`. Somehow the code doesn't crash but when running it trough tree shaking tools it will cause an error. The error might have been caused by some eager refactoring of the code :).