### PR TITLE
Fix case typo in UtilityService.getPackageVersion

### DIFF
--- a/lib/utilityservice.js
+++ b/lib/utilityservice.js
@@ -400,7 +400,7 @@ UtilityService.prototype.getPackageVersion = async function() {
     
     VlocityUtils.verbose('Get Package Version');
 
-    if (!this.vlocity.packageVersion) {
+    if (!this.vlocity.PackageVersion) {
         var result = await this.vlocity.jsForceConnection.query("SELECT DurableId, Id, IsSalesforce, MajorVersion, MinorVersion, Name, NamespacePrefix FROM Publisher where NamespacePrefix = \'" + this.vlocity.namespace + "\' LIMIT 1");
 
         this.vlocity.buildToolsVersionSettings = yaml.safeLoad(fs.readFileSync(path.join(__dirname, "buildToolsVersionSettings.yaml"), 'utf8'));


### PR DESCRIPTION
The code in `UtilityService.getPackageVersion` should only run if we do not yet know the PackageVersion, but it checks if `this.vlocity.packageVersion` is set which is never being set, instead `this.vlocity.PackageVersion` is being set (see line 411)

I expect the the intend from the author must have been not to run query the package version multiple times when the package version is already known.