### PR TITLE
Fixes problem: SyntaxError: Unexpected token o in JSON at position

### DIFF
--- a/lib/datapacksjob.js
+++ b/lib/datapacksjob.js
@@ -1575,17 +1575,21 @@ DataPacksJob.prototype.installFromStaticResourceQuery = async function(jobInfo, 
 
             optionsForInstall.ignoreAllErrors = true;
 
-            let result = await this.vlocity.datapacks.import(JSON.parse(res), optionsForInstall);
+            const importData = typeof res === 'object'
+                ? res
+                : JSON.parse(res);
+
+            let result = await this.vlocity.datapacks.import(importData, optionsForInstall);
             
             let dataPackData = await this.vlocity.datapacks.getDataPackData(result.VlocityDataPackId);
             
-            if (dataPackData.status == 'Complete') {
+            if (dataPackData.status === 'Complete') {
 
                 VlocityUtils.success('Resource Deployed', record.Name);
 
                 for (var dataPack of dataPackData.dataPacks) {
 
-                    if (dataPack.VlocityDataPackStatus == 'Success') {
+                    if (dataPack.VlocityDataPackStatus === 'Success') {
                         VlocityUtils.success('Deploy Success', dataPack.VlocityDataPackType, '-', dataPack.VlocityDataPackKey, '-', dataPack.VlocityDataPackName);
                     } else {
                         VlocityUtils.error('Deploy Error', dataPack.VlocityDataPackType, '-', dataPack.VlocityDataPackKey, '-', dataPack.VlocityDataPackName, '-', dataPack.VlocityDataPackMessage);


### PR DESCRIPTION
```
Failed to Install >> DP_CUSTOM_Frame_Contracts SyntaxError: Unexpected token o in JSON at position 1

                  at JSON.parse (<anonymous>)
                  at module.exports.DataPacksJob.installFromStaticResourceQuery (/home/vsts/work/1/s/node_modules/vlocity/lib/datapacksjob.js:1578:67)
                  at runMicrotasks (<anonymous>)
                  at processTicksAndRejections (internal/process/task_queues.js:97:5)
                  at async module.exports.DataPacksJob.installVlocityInitial (/home/vsts/work/1/s/node_modules/vlocity/lib/datapacksjob.js:1559:5)
                  at async module.exports.DataPacksJob.doRunJob (/home/vsts/work/1/s/node_modules/vlocity/lib/datapacksjob.js:328:9)
                  at async module.exports.DataPacksJob.runJobWithInfo (/home/vsts/work/1/s/node_modules/vlocity/lib/datapacksjob.js:263:9)
                  at async module.exports.DataPacksJob.runJob (/home/vsts/work/1/s/node_modules/vlocity/lib/datapacksjob.js:76:26)
                  at async Function.Vlocity.runDataPacksCommand (/home/vsts/work/1/s/node_modules/vlocity/lib/vlocity.js:144:12)
                  at async module.exports.VlocityCLI.runJob (/home/vsts/work/1/s/node_modules/vlocity/lib/vlocitycli.js:624:12)
                  at async module.exports.VlocityCLI.runCommands (/home/vsts/work/1/s/node_modules/vlocity/lib/vlocitycli.js:522:23)
                  at async Function.VlocityCLI.runCLI (/home/vsts/work/1/s/node_modules/vlocity/lib/vlocitycli.js:327:22)
                  at async /home/vsts/work/1/s/node_modules/vlocity/lib/vlocitybuild.js:7:9

```

In this case the DP_CUSTOM_Frame_Contracts static resource is of type application/json, which returns the response as object: 
![image](https://user-images.githubusercontent.com/973711/86338349-843aaf00-bc52-11ea-9f75-a880825fea04.png)

