### PR TITLE
Fix Product2 Export when they Don't have AA

### DIFF
--- a/lib/datapacksexpand.js
+++ b/lib/datapacksexpand.js
@@ -621,11 +621,12 @@ DataPacksExpand.prototype.preprocessSObjects = async function(currentData, dataP
                         if (field.indexOf('.') != -1) {
                             try {
                                 var splitFields = field.split('.');
-
-                                if (currentData[splitFields[0]]) {
+                                if (currentData[splitFields[0]] && currentData[splitFields[0]].length > 0) {
                                     var nestedData = { [splitFields[0]]: JSON.parse(currentData[splitFields[0]]) };
-                                    self.filterNestedField(nestedData, field);
-                                    currentData[splitFields[0]] = stringify(nestedData[splitFields[0]]);
+                                    if(nestedData && nestedData.length > 0){
+                                        self.filterNestedField(nestedData, field);
+                                        currentData[splitFields[0]] = stringify(nestedData[splitFields[0]]);
+                                    }
                                 }
                             } catch (e) {
                                 VlocityUtils.error('Failure in nested parsing', e);


### PR DESCRIPTION
This fixes the following error when exporting Products with no AA:

     Failure in nested parsing >> TypeError: Cannot convert undefined or null to object
        at module.exports.DataPacksExpand.filterNestedField (/Users/jgarciagonzalez/REPOS/Vlocity/vlocity_build/lib/datapacksexpand.js:467:28)
        at module.exports.DataPacksExpand.filterNestedField (/Users/jgarciagonzalez/REPOS/Vlocity/vlocity_build/lib/datapacksexpand.js:477:18)
        at module.exports.DataPacksExpand.filterNestedField (/Users/jgarciagonzalez/REPOS/Vlocity/vlocity_build/lib/datapacksexpand.js:477:18)
        at /Users/jgarciagonzalez/REPOS/Vlocity/vlocity_build/lib/datapacksexpand.js:627:42
        at Array.forEach (<anonymous>)
        at module.exports.DataPacksExpand.preprocessSObjects (/Users/jgarciagonzalez/REPOS/Vlocity/vlocity_build/lib/datapacksexpand.js:618:34)
        at module.exports.DataPacksExpand.preprocessDataPack (/Users/jgarciagonzalez/REPOS/Vlocity/vlocity_build/lib/datapacksexpand.js:782:32)
        at module.exports.DataPacksExpand.expand (/Users/jgarciagonzalez/REPOS/Vlocity/vlocity_build/lib/datapacksexpand.js:1478:24)
        at processTicksAndRejections (internal/process/task_queues.js:97:5)
        at async module.exports.DataPacksJob.exportGroup (/Users/jgarciagonzalez/REPOS/Vlocity/vlocity_build/lib/datapacksjob.js:1522:13) 