### PR TITLE
LWC for OS Activation #2

### DIFF
--- a/lib/datapacktypes/omniscript.js
+++ b/lib/datapacktypes/omniscript.js
@@ -91,7 +91,7 @@ OmniScript.prototype.afterActivationSuccess = async function(inputMap) {
     var jobInfo = inputMap.jobInfo;
     var dataPack = inputMap.dataPack;
 
-    if(!jobInfo.checkLWCActivation){
+    if(!jobInfo.ignoreLWCActivation && !jobInfo.checkLWCActivation){
         var minVersions = yaml.safeLoad(fs.readFileSync(path.join(__dirname,'..', 'buildToolsMinVersionOS-LWC.yaml'), 'utf8'));
         var minVersion = minVersions[this.vlocity.namespace]
         var currentVersion = this.vlocity.PackageVersion;
@@ -100,6 +100,16 @@ OmniScript.prototype.afterActivationSuccess = async function(inputMap) {
             VlocityUtils.error('LWC Activation', 'Unsupported Managed package Version, LWC Activation disabled');
         }
         jobInfo.checkLWCActivation = true;
+    }
+
+    if (jobInfo.isRetry && jobInfo.omniScriptLwcActivationSkip[dataPack.VlocityDataPackKey]) { 
+        var oldError = jobInfo.omniScriptLwcActivationSkip[dataPack.VlocityDataPackKey];
+        jobInfo.hasError = true;
+        jobInfo.currentStatus[dataPack.VlocityDataPackKey] = 'Error';
+        jobInfo.currentErrors[dataPack.VlocityDataPackKey] = 'LWC Activation Error >> ' + dataPack.VlocityDataPackKey + oldError;
+        jobInfo.errors.push('LWC Activation Error >> ' + dataPack.VlocityDataPackKey + oldError);
+        VlocityUtils.error('LWC Activation Error', dataPack.VlocityDataPackKey + oldError);
+        return;
     }
 
     if (jobInfo.ignoreLWCActivation) {
@@ -176,7 +186,15 @@ OmniScript.prototype.afterActivationSuccess = async function(inputMap) {
                 var siteUrl = this.vlocity.jsForceConnection.instanceUrl;
                 var sessionToken = this.vlocity.jsForceConnection.accessToken;
                 var loginURl = siteUrl + '/secur/frontdoor.jsp?sid=' + sessionToken;
-                const browser = await puppeteer.launch(puppeteerOptions);
+                var browser;
+                try {
+                    browser = await puppeteer.launch(puppeteerOptions);
+                } catch (error) {
+                    VlocityUtils.error('Puppeteer initialization Failed, LWC Activation disabled - ' + error);
+                    jobInfo.ignoreLWCActivation = true;
+                    return;
+                }
+                
                 const page = await browser.newPage();
                 const loginTimeout = 300000;
 
@@ -224,6 +242,10 @@ OmniScript.prototype.afterActivationSuccess = async function(inputMap) {
                 }
 
                 if(errorMessage) {
+                    if(!jobInfo.omniScriptLwcActivationSkip){
+                        jobInfo.omniScriptLwcActivationSkip = {};
+                    }
+                    jobInfo.omniScriptLwcActivationSkip[dataPack.VlocityDataPackKey] = errorMessage;
                     jobInfo.hasError = true;
                     jobInfo.currentStatus[dataPack.VlocityDataPackKey] = 'Error';
                     jobInfo.currentErrors[dataPack.VlocityDataPackKey] = 'LWC Activation Error >> ' + dataPack.VlocityDataPackKey + errorMessage;


### PR DESCRIPTION
Change:

- Check if ignoreLWCActivation before Manage Package version check.

New:

- Ignore LWC Activation on Retry
- Disable LWC Activation if Puppeteer fails to load