### PR TITLE
Save puppeteer Executable Path in jobInfo when found

### DIFF
--- a/lib/datapacktypes/omniscript.js
+++ b/lib/datapacktypes/omniscript.js
@@ -153,13 +153,10 @@ OmniScript.prototype.afterActivationSuccess = async function(inputMap) {
                 puppeteerOptions.executablePath = jobInfo.puppeteerExecutablePath;
             } else if (fs.existsSync(macChrome)) {
                 puppeteerOptions.executablePath = macChrome;
-                jobInfo.puppeteerExecutablePath = puppeteerOptions.executablePath;
             } else if (fs.existsSync(winChrome)) {
                 puppeteerOptions.executablePath = winChrome;
-                jobInfo.puppeteerExecutablePath = puppeteerOptions.executablePath;
             } else if (fs.existsSync(winChrome86)) {
                 puppeteerOptions.executablePath = winChrome86;
-                jobInfo.puppeteerExecutablePath = puppeteerOptions.executablePath;
             } else {
                 let chromiumDirLocal = path.join('.', 'node_modules', 'puppeteer', '.local-chromium');
                 if (fs.existsSync(chromiumDirLocal)) {
@@ -170,13 +167,10 @@ OmniScript.prototype.afterActivationSuccess = async function(inputMap) {
 
                         if (fs.existsSync(macApp)) {
                             puppeteerOptions.executablePath = macApp;
-                            jobInfo.puppeteerExecutablePath = puppeteerOptions.executablePath;
                         } else if (fs.existsSync(linuxApp)) {
                             puppeteerOptions.executablePath = linuxApp;
-                            jobInfo.puppeteerExecutablePath = puppeteerOptions.executablePath;
                         } else if (fs.existsSync(winApp)) {
                             puppeteerOptions.executablePath = winApp;
-                            jobInfo.puppeteerExecutablePath = puppeteerOptions.executablePath;
                         }
                     });
                 }
@@ -192,13 +186,10 @@ OmniScript.prototype.afterActivationSuccess = async function(inputMap) {
 
                                 if (fs.existsSync(macApp)) {
                                     puppeteerOptions.executablePath = macApp;
-                                    jobInfo.puppeteerExecutablePath = puppeteerOptions.executablePath;
                                 } else if (fs.existsSync(linuxApp)) {
                                     puppeteerOptions.executablePath = linuxApp;
-                                    jobInfo.puppeteerExecutablePath = puppeteerOptions.executablePath;
                                 } else if (fs.existsSync(winApp)) {
                                     puppeteerOptions.executablePath = winApp;
-                                    jobInfo.puppeteerExecutablePath = puppeteerOptions.executablePath;
                                 }
                             });
                         }   
@@ -210,6 +201,7 @@ OmniScript.prototype.afterActivationSuccess = async function(inputMap) {
                 VlocityUtils.error('Chromium not installed. LWC activation disabled. Run "npm install puppeteer -g" or set puppeteerExecutablePath in your Job File');
                 jobInfo.ignoreLWCActivation = true;
             } else {
+                jobInfo.puppeteerExecutablePath = puppeteerOptions.executablePath;
                 var package = this.vlocity.namespacePrefix;
             
                 var siteUrl = this.vlocity.jsForceConnection.instanceUrl;

--- a/lib/datapacktypes/omniscript.js
+++ b/lib/datapacktypes/omniscript.js
@@ -1,4 +1,5 @@
 var vlocity = require('../vlocity');
+var utilityservice = require('../utilityservice');
 var puppeteer = require('puppeteer-core');
 var fs = require('fs-extra');
 var path = require('path');
@@ -140,68 +141,12 @@ OmniScript.prototype.afterActivationSuccess = async function(inputMap) {
         }
         try {
 
-            let puppeteerOptions = { 
-                headless: true,
-                args: ['--no-sandbox']
-            };
-
-            let macChrome = path.join('/', 'Applications', 'Google Chrome.app', 'Contents', 'MacOS', 'Google Chrome');
-            let winChrome = path.join('/', 'Program Files', 'Google', 'Chrome', 'Application', 'chrome.exe');
-            let winChrome86 = path.join('/', 'Program Files (x86)', 'Google', 'Chrome', 'Application', 'chrome.exe');
+            let puppeteerOptions = await utilityservice.prototype.getPuppeteerOptions(jobInfo);
  
-            if (jobInfo.puppeteerExecutablePath) {
-                puppeteerOptions.executablePath = jobInfo.puppeteerExecutablePath;
-            } else if (fs.existsSync(macChrome)) {
-                puppeteerOptions.executablePath = macChrome;
-            } else if (fs.existsSync(winChrome)) {
-                puppeteerOptions.executablePath = winChrome;
-            } else if (fs.existsSync(winChrome86)) {
-                puppeteerOptions.executablePath = winChrome86;
-            } else {
-                let chromiumDirLocal = path.join('.', 'node_modules', 'puppeteer', '.local-chromium');
-                if (fs.existsSync(chromiumDirLocal)) {
-                    fs.readdirSync(chromiumDirLocal).forEach((file) => {
-                        let macApp = path.join(chromiumDirLocal, file, 'chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium');
-                        let linuxApp =  path.join(chromiumDirLocal, file, 'chrome-linux', 'chrome');
-                        let winApp =  path.join(chromiumDirLocal, file, 'chrome-win', 'chrome.exe');
-
-                        if (fs.existsSync(macApp)) {
-                            puppeteerOptions.executablePath = macApp;
-                        } else if (fs.existsSync(linuxApp)) {
-                            puppeteerOptions.executablePath = linuxApp;
-                        } else if (fs.existsSync(winApp)) {
-                            puppeteerOptions.executablePath = winApp;
-                        }
-                    });
-                }
-                if (!puppeteerOptions.executablePath) {
-                    let pathToPuppeteer = require("global-modules-path").getPath("puppeteer", "puppeteer");
-                    if (pathToPuppeteer) {
-                        let chromiumDirGlobal = path.join(pathToPuppeteer, '.local-chromium');
-                        if (fs.existsSync(chromiumDirGlobal)) {
-                            fs.readdirSync(chromiumDirGlobal).forEach((file) => {
-                                let macApp = path.join(chromiumDirGlobal, file, 'chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium');
-                                let linuxApp =  path.join(chromiumDirGlobal, file, 'chrome-linux', 'chrome');
-                                let winApp =  path.join(chromiumDirGlobal, file, 'chrome-win', 'chrome.exe');
-
-                                if (fs.existsSync(macApp)) {
-                                    puppeteerOptions.executablePath = macApp;
-                                } else if (fs.existsSync(linuxApp)) {
-                                    puppeteerOptions.executablePath = linuxApp;
-                                } else if (fs.existsSync(winApp)) {
-                                    puppeteerOptions.executablePath = winApp;
-                                }
-                            });
-                        }   
-                    }
-                }
-            }
-            
             if (!puppeteerOptions.executablePath && !jobInfo.puppeteerInstalled) {
                 VlocityUtils.error('Chromium not installed. LWC activation disabled. Run "npm install puppeteer -g" or set puppeteerExecutablePath in your Job File');
                 jobInfo.ignoreLWCActivation = true;
             } else {
-                jobInfo.puppeteerExecutablePath = puppeteerOptions.executablePath;
                 var package = this.vlocity.namespacePrefix;
             
                 var siteUrl = this.vlocity.jsForceConnection.instanceUrl;
@@ -235,13 +180,14 @@ OmniScript.prototype.afterActivationSuccess = async function(inputMap) {
                 
                 let tries = 0;
                 var errorMessage;
-                while (tries < 20 && !jobInfo.ignoreLWCActivation) {
+                var maxNumOfTries = jobInfo.defaultMinToWaitForLWC*2;
+                while (tries < maxNumOfTries && !jobInfo.ignoreLWCActivation) {
                     try {
                         let message;
                         try {
                             message = await page.waitForSelector('#compiler-message');
                         } catch (messageTimeout) {
-                            VlocityUtils.log(dataPack.VlocityDataPackKey, 'Loading Page taking too long - Retrying - Tries: ' + tries + ' of 20');
+                            VlocityUtils.log(dataPack.VlocityDataPackKey, 'Loading Page taking too long - Retrying - Tries: ' + tries + ' of ' + maxNumOfTries);
                         }
                         
                         if (message) { 
@@ -267,8 +213,8 @@ OmniScript.prototype.afterActivationSuccess = async function(inputMap) {
                     await page.waitForTimeout(30000);
                 }
 
-                if (tries == 20) {
-                    errorMessage = 'Activation took longer than 10 minutes - Aborting';
+                if (tries == maxNumOfTries) {
+                    errorMessage = 'Activation took longer than ' + defaultMinToWaitForLWC + ' minutes - Aborting';
                 }
 
                 if (errorMessage) {

--- a/lib/datapacktypes/omniscript.js
+++ b/lib/datapacktypes/omniscript.js
@@ -153,10 +153,13 @@ OmniScript.prototype.afterActivationSuccess = async function(inputMap) {
                 puppeteerOptions.executablePath = jobInfo.puppeteerExecutablePath;
             } else if (fs.existsSync(macChrome)) {
                 puppeteerOptions.executablePath = macChrome;
+                jobInfo.puppeteerExecutablePath = puppeteerOptions.executablePath;
             } else if (fs.existsSync(winChrome)) {
                 puppeteerOptions.executablePath = winChrome;
+                jobInfo.puppeteerExecutablePath = puppeteerOptions.executablePath;
             } else if (fs.existsSync(winChrome86)) {
                 puppeteerOptions.executablePath = winChrome86;
+                jobInfo.puppeteerExecutablePath = puppeteerOptions.executablePath;
             } else {
                 let chromiumDirLocal = path.join('.', 'node_modules', 'puppeteer', '.local-chromium');
                 if (fs.existsSync(chromiumDirLocal)) {
@@ -167,10 +170,13 @@ OmniScript.prototype.afterActivationSuccess = async function(inputMap) {
 
                         if (fs.existsSync(macApp)) {
                             puppeteerOptions.executablePath = macApp;
+                            jobInfo.puppeteerExecutablePath = puppeteerOptions.executablePath;
                         } else if (fs.existsSync(linuxApp)) {
                             puppeteerOptions.executablePath = linuxApp;
+                            jobInfo.puppeteerExecutablePath = puppeteerOptions.executablePath;
                         } else if (fs.existsSync(winApp)) {
                             puppeteerOptions.executablePath = winApp;
+                            jobInfo.puppeteerExecutablePath = puppeteerOptions.executablePath;
                         }
                     });
                 }
@@ -186,10 +192,13 @@ OmniScript.prototype.afterActivationSuccess = async function(inputMap) {
 
                                 if (fs.existsSync(macApp)) {
                                     puppeteerOptions.executablePath = macApp;
+                                    jobInfo.puppeteerExecutablePath = puppeteerOptions.executablePath;
                                 } else if (fs.existsSync(linuxApp)) {
                                     puppeteerOptions.executablePath = linuxApp;
+                                    jobInfo.puppeteerExecutablePath = puppeteerOptions.executablePath;
                                 } else if (fs.existsSync(winApp)) {
                                     puppeteerOptions.executablePath = winApp;
+                                    jobInfo.puppeteerExecutablePath = puppeteerOptions.executablePath;
                                 }
                             });
                         }   

--- a/lib/defaultjobsettings.yaml
+++ b/lib/defaultjobsettings.yaml
@@ -10,6 +10,7 @@ activate: true
 compileOnBuild: true
 maxDepth: -1
 defaultMaxParallel: 100
+defaultMinToWaitForLWC: 10
 exportPacksMaxSize: 5
 useAllRelationships: false
 ignoreAllErrors: false

--- a/lib/utilityservice.js
+++ b/lib/utilityservice.js
@@ -1474,3 +1474,68 @@ UtilityService.prototype.moveFolders = async function (source, target) {
     await fs.copy(source, target);
     await fs.removeSync(source);
 }
+
+UtilityService.prototype.getPuppeteerOptions = async function (jobInfo) {
+    let puppeteerOptions = { 
+        headless: true,
+        args: ['--no-sandbox']
+    };
+
+    let macChrome = path.join('/', 'Applications', 'Google Chrome.app', 'Contents', 'MacOS', 'Google Chrome');
+    let winChrome = path.join('/', 'Program Files', 'Google', 'Chrome', 'Application', 'chrome.exe');
+    let winChrome86 = path.join('/', 'Program Files (x86)', 'Google', 'Chrome', 'Application', 'chrome.exe');
+
+    if (jobInfo.puppeteerExecutablePath) {
+        puppeteerOptions.executablePath = jobInfo.puppeteerExecutablePath;
+    } else if (fs.existsSync(macChrome)) {
+        puppeteerOptions.executablePath = macChrome;
+    } else if (fs.existsSync(winChrome)) {
+        puppeteerOptions.executablePath = winChrome;
+    } else if (fs.existsSync(winChrome86)) {
+        puppeteerOptions.executablePath = winChrome86;
+    } else {
+        let chromiumDirLocal = path.join('.', 'node_modules', 'puppeteer', '.local-chromium');
+        if (fs.existsSync(chromiumDirLocal)) {
+            fs.readdirSync(chromiumDirLocal).forEach((file) => {
+                let macApp = path.join(chromiumDirLocal, file, 'chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium');
+                let linuxApp =  path.join(chromiumDirLocal, file, 'chrome-linux', 'chrome');
+                let winApp =  path.join(chromiumDirLocal, file, 'chrome-win', 'chrome.exe');
+
+                if (fs.existsSync(macApp)) {
+                    puppeteerOptions.executablePath = macApp;
+                } else if (fs.existsSync(linuxApp)) {
+                    puppeteerOptions.executablePath = linuxApp;
+                } else if (fs.existsSync(winApp)) {
+                    puppeteerOptions.executablePath = winApp;
+                }
+            });
+        }
+        if (!puppeteerOptions.executablePath) {
+            let pathToPuppeteer = require("global-modules-path").getPath("puppeteer", "puppeteer");
+            if (pathToPuppeteer) {
+                let chromiumDirGlobal = path.join(pathToPuppeteer, '.local-chromium');
+                if (fs.existsSync(chromiumDirGlobal)) {
+                    fs.readdirSync(chromiumDirGlobal).forEach((file) => {
+                        let macApp = path.join(chromiumDirGlobal, file, 'chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium');
+                        let linuxApp =  path.join(chromiumDirGlobal, file, 'chrome-linux', 'chrome');
+                        let winApp =  path.join(chromiumDirGlobal, file, 'chrome-win', 'chrome.exe');
+
+                        if (fs.existsSync(macApp)) {
+                            puppeteerOptions.executablePath = macApp;
+                        } else if (fs.existsSync(linuxApp)) {
+                            puppeteerOptions.executablePath = linuxApp;
+                        } else if (fs.existsSync(winApp)) {
+                            puppeteerOptions.executablePath = winApp;
+                        }
+                    });
+                }   
+            }
+        }
+    }
+
+    if (puppeteerOptions.executablePath) {
+        jobInfo.puppeteerExecutablePath = puppeteerOptions.executablePath;
+    }
+    //console.log(puppeteerOptions);
+    return puppeteerOptions;
+}


### PR DESCRIPTION
Save puppeteer Executable Path in jobInfo if found so it can be reused