### PR TITLE
Add this.vlocity.organizationId when using session Id

### DIFF
--- a/lib/utilityservice.js
+++ b/lib/utilityservice.js
@@ -365,6 +365,10 @@ UtilityService.prototype.checkLogin = async function() {
         if (this.vlocity.sessionId || this.vlocity.accessToken) {
             await this.getNamespace();
             await this.checkRequiredVersion();
+            var identity = await this.vlocity.jsForceConnection.identity();
+            if (identity) {
+                this.vlocity.organizationId = identity.organization_id;
+            }
         } else if (this.vlocity.sfdxUsername && this.vlocity.sfdxUsername != "VLOCITY_API_LOGIN") {
             await this.sfdxLogin();
             await this.getNamespace();


### PR DESCRIPTION
@rutlabaga  

This sets this.vlocity.organizationId when using Session id.

The setting is not used anywhere but it is enforced in packUpdateSetting and when using session Id this value is never set so packUpdateSettings is failing when using session Id.

Another fix will be to delete lines 1697 to 1699 in datapackjobs since this.vlocity.organizationId is never used. 