### PR TITLE
Set the VlocityDataPackType in the JSON output when a data pack is removed from deployment due to a compilation error

### DIFF
--- a/lib/datapacksbuilder.js
+++ b/lib/datapacksbuilder.js
@@ -202,6 +202,14 @@ DataPacksBuilder.prototype.buildImport = async function(importPath, jobInfo, val
     if (dataPackImport.dataPacks.length > 0) {
         VlocityUtils.success(jobInfo.jobAction, dataPackImport.dataPacks.length, 'Items');
 
+        for (var dataPack of dataPackImport.dataPacks) {
+            var data = jobInfo.allDataSummary[dataPack.VlocityDataPackKey];
+
+            if (data) {
+                data.VlocityDataPackType = dataPack.VlocityDataPackType;
+            }
+        }
+
         if (jobInfo.compileOnBuild) {
 
             let result = await self.compileQueuedData();

--- a/lib/datapacksjob.js
+++ b/lib/datapacksjob.js
@@ -2240,7 +2240,6 @@ DataPacksJob.prototype.deployPack = async function(inputMap) {
             var data = jobInfo.allDataSummary[dataPack.VlocityDataPackKey];
 
             if (data) {
-                data.VlocityDataPackType = dataPack.VlocityDataPackType;
                 preStepDeployData.push(data);
             }
         }


### PR DESCRIPTION
### What does this change?
At the moment, if we try to deploy a SASS file that doesn't compile, the JSON output doesn't include VlocityDataPackType.
The JSON output does include an entry for the data pack that couldn't be deployed.
I'm parsing this JSON output and want to include the VlocityDataPackType for SASS files that don't compile.

We can reproduce this by deploying a VlocityUITemplate with a .scss file that has an import referencing a file that doesn't exist in the deployment.
In the `projectPath` directory in the job file, we create a data pack `VlocityUITemplate\campaign-base-grid` with a `campaign-base-grid.scss` file.
At the start of `campaign-base-grid.scss` file, we have `@import "campaign-variables";`, which doesn't exist in a deployment.

When we run `vlocity packDeploy -job DataPackJob.yaml -propertyfile source.properties -json` to deploy the data pack, the current output for this data pack (in the `records` property of the JSON) is:
```
        {
            "VlocityDataPackKey": "VlocityUITemplate/campaign-base-grid",
            "VlocityRecordSObjectType": "%vlocity_namespace%__VlocityUITemplate__c",
            "Name": "campaign-base-grid",
            "VlocityRecordSourceKey": "%vlocity_namespace%__VlocityUITemplate__c/campaign-base-grid",
            "VlocityDataPackStatus": "Error",
            "VlocityDataPackDisplayLabel": "campaign-base-grid (VlocityUITemplate/campaign-base-grid)",
            "ErrorMessage": "SASS Compilation Error Failed to compile SCSS: {PROJECT_PATH}\\VlocityUITemplate\\campaign-base-grid\\campaign-base-grid.scss SASS compilation failed, see error message for details: Error: \n        on line 2:9 of /stdin\n>> @import \"campaign-variables\";\n\n   --------^\n"
        }
```

With this change, the output has the `VlocityDataPackType` key:
```
        {
            "VlocityDataPackKey": "VlocityUITemplate/campaign-base-grid",
            "VlocityRecordSObjectType": "%vlocity_namespace%__VlocityUITemplate__c",
            "Name": "campaign-base-grid",
            "VlocityRecordSourceKey": "%vlocity_namespace%__VlocityUITemplate__c/campaign-base-grid",
            "VlocityDataPackType": "VlocityUITemplate",
            "VlocityDataPackStatus": "Error",
            "VlocityDataPackDisplayLabel": "campaign-base-grid (VlocityUITemplate/campaign-base-grid)",
            "ErrorMessage": "SASS Compilation Error Failed to compile SCSS: {PROJECT_PATH}\\deploy\\VlocityUITemplate\\campaign-base-grid\\campaign-base-grid.scss SASS compilation failed, see error message for details: Error: \n        on line 2:9 of /stdin\n>> @import \"campaign-variables\";\n\n   --------^\n"
        }
```

### How else did I consider implementing this?

I considered adding the `VlocityDataPackType` in `DataPacksBuilder.initializeTypeAtPath` by setting a property on `apexImportData`.
https://github.com/vlocityinc/vlocity_build/blob/905ccca4d643302cdaddb8a25aeced07a7996ef2/lib/datapacksbuilder.js#L572-L576.

I considered adding the `VlocityDataPackType` in `DataPacksJob.formatResponse` in a similar way to how we set `VlocityDataPackDisplayLabel `.
https://github.com/vlocityinc/vlocity_build/blob/905ccca4d643302cdaddb8a25aeced07a7996ef2/lib/datapacksjob.js#L569-L571

Both of these felt like they were workarounds to the real problem.

### How is this tested?

I couldn't find a good jumping off point for writing any unit tests for this. If you've got any suggestions, please let me know.

I've checked manually that:
- an export writes exactly the same files as before
- the deployment includes the `VlocityDataPackType` on data packs that don't compile and are removed from the deployment
- the deployment includes the `VlocityDataPackType` on data packs that are deployed (as before)