### PR TITLE
Add LWC Job options to CLI arguments

### DIFF
--- a/lib/vlocitycli.js
+++ b/lib/vlocitycli.js
@@ -101,7 +101,9 @@ var VLOCITY_COMMANDLINE_OPTIONS = {
     "defaultMinToWaitForLWCClassicCards": Number,
     "defaultMinToWaitForLWCFlexCards": Number,
     "defaultLWCPullTimeInSeconds": Number,
-    "puppeteerHeadless": Boolean
+    "puppeteerHeadless": Boolean,
+    "ignoreLWCActivationOS": Boolean,
+    "ignoreLWCActivationCards": Boolean
 };
 
 var VLOCITY_COMMANDLINE_OPTIONS_SHORTHAND = {

--- a/lib/vlocitycli.js
+++ b/lib/vlocitycli.js
@@ -96,7 +96,12 @@ var VLOCITY_COMMANDLINE_OPTIONS = {
     "outputDir": String,
     "upgradeDataPackFields": Boolean,
     "inlcudeDependencies": Boolean,
-    "testKeys": Array
+    "testKeys": Array,
+    "defaultMinToWaitForLWCOmniScript": Number,
+    "defaultMinToWaitForLWCClassicCards": Number,
+    "defaultMinToWaitForLWCFlexCards": Number,
+    "defaultLWCPullTimeInSeconds": Number,
+    "puppeteerHeadless": Boolean
 };
 
 var VLOCITY_COMMANDLINE_OPTIONS_SHORTHAND = {


### PR DESCRIPTION
Add LWC Job options to CLI arguments: 
    "defaultMinToWaitForLWCOmniScript": Number
    "defaultMinToWaitForLWCClassicCards": Number
    "defaultMinToWaitForLWCFlexCards": Number
    "defaultLWCPullTimeInSeconds": Number
    "puppeteerHeadless": Boolean
    "ignoreLWCActivationOS": Boolean
    "ignoreLWCActivationCards": Boolean