### PR TITLE
Fix the SOQL query for the `VlocityTrackingGroup` query definition

### DIFF
--- a/lib/querydefinition.yaml
+++ b/lib/querydefinition.yaml
@@ -214,7 +214,7 @@ VlocityWebTrackingConfiguration:
   query: Select Id, %vlocity_namespace%__GlobalKey__c from %vlocity_namespace%__VlocityWebTrackingConfiguration__c
 VlocityTrackingGroup:
   VlocityDataPackType: VlocityTrackingGroup
-  query: Select Id, %vlocity_namespace%__GlobalKey__c from %vlocity_namespace%____VlocityTrackingGroup__c
+  query: Select Id, %vlocity_namespace%__GlobalKey__c from %vlocity_namespace%__VlocityTrackingGroup__c
 VqMachine:
   VlocityDataPackType: VqMachine
   query: Select Id, Name from %vlocity_namespace%__VqMachine__c


### PR DESCRIPTION
This PR fixes the query definition for `VlocityTrackingGroup`. We've been seeing some `INVALID_TYPE` errors when using this query. The problem is that there were 4 underscores between the namespace prefix instead of 2, so the object name in the SOQL query was invalid.

`packExport` output before this change:
```
  Retrieving Vlocity
  VlocityDataPackType >> VlocityTrackingGroup  
  Query >> Select Id, vlocity_ins__GlobalKey__c from vlocity_ins____VlocityTrackingGroup__c  
  Query Error >> INVALID_TYPE:
vlocity_ins__GlobalKey__c from vlocity_ins____VlocityTrackingGroup__c
                               ^
ERROR at Row:1:Column:43
sObject type 'vlocity_ins____VlocityTrackingGroup__c' is not supported. If you are attempting to use a custom object, be sure to append the '__c' after the entity name. Please reference your WSDL or the describe call for the appropriate names.
    at HttpApi.getError (C:\Users\Tom\AppData\Roaming\npm\node_modules\vlocity\node_modules\jsforce\lib\http-api.js:250:13)
    at C:\Users\Tom\AppData\Roaming\npm\node_modules\vlocity\node_modules\jsforce\lib\http-api.js:95:22
    at tryCallOne (C:\Users\Tom\AppData\Roaming\npm\node_modules\vlocity\node_modules\promise\lib\core.js:37:12)
    at C:\Users\Tom\AppData\Roaming\npm\node_modules\vlocity\node_modules\promise\lib\core.js:123:15
    at flush (C:\Users\Tom\AppData\Roaming\npm\node_modules\vlocity\node_modules\asap\raw.js:50:29)
    at processTicksAndRejections (node:internal/process/task_queues:78:11)
  Initializing Project  
  Finishing Retrieve  
  Job Complete >> Export  
```

`packExport` output after this change:
```
  Retrieving Vlocity  
  VlocityDataPackType >> VlocityTrackingGroup  
  Query >> Select Id, vlocity_ins__GlobalKey__c from vlocity_ins__VlocityTrackingGroup__c  
  Records >> 0
```

Along with the already merged change in https://github.com/vlocityinc/vlocity_build/commit/f358835d80f15f8cb6651a5ae069b176bc172c44#diff-25ec22cef63b2a903f015652ddc6f41f3b6b7f61a9d4fb14c23b62c044653279R190, I think this PR fixes https://github.com/vlocityinc/vlocity_build/issues/364.