### PR TITLE
Chromium proxy server set with sf.httpProxy

### DIFF
--- a/lib/utilityservice.js
+++ b/lib/utilityservice.js
@@ -1508,7 +1508,10 @@ UtilityService.prototype.moveFolders = async function (source, target) {
 UtilityService.prototype.getPuppeteerOptions = async function (jobInfo) {
     let puppeteerOptions = { 
         headless: jobInfo.puppeteerHeadless,
-        args: ['--no-sandbox']
+        args: [
+            '--no-sandbox',
+            `--proxy-server=${jobInfo.httpProxy ? jobInfo.httpProxy : ''}`
+        ]
     };
 
     let macChrome = path.join('/', 'Applications', 'Google Chrome.app', 'Contents', 'MacOS', 'Google Chrome');


### PR DESCRIPTION
Applying --proxy-server into Puppeteer to make the tool work properly behind a proxy server. Without it sfdx part would work properly with a proxy and only a part of a tool will not work and forced the tool to raise net::ERR_TUNNEL_CONNECTION_FAILED error.

Related issue: https://github.com/vlocityinc/vlocity_build/issues/400