### PR TITLE
W-10179420 Adds cleanup of tempDeployLwc folder before running datapack jobs

### DIFF
--- a/lib/datapacksjob.js
+++ b/lib/datapacksjob.js
@@ -2499,7 +2499,15 @@ DataPacksJob.prototype.deployPack = async function(inputMap) {
 
 DataPacksJob.prototype.deployJob = async function(jobInfo) {
 
+    let tempSfdxLwcFolder = path.join(jobInfo.tempFolder, 'tempDeployLWC', 'salesforce_sfdx');
+
     if (!jobInfo.isRetry) {        
+
+        // Cleanup LWC temp folder
+        if(fs.existsSync(tempSfdxLwcFolder)){
+            fs.emptyDirSync(tempSfdxLwcFolder);
+        }
+
         if (jobInfo.includeSalesforceMetadata) {
             await this.deploySalesforce(jobInfo);
             if (jobInfo.hasError) {
@@ -2649,17 +2657,16 @@ DataPacksJob.prototype.deployJob = async function(jobInfo) {
 
     // Deploy LWC components
     if(jobInfo.deployGeneratedLwc === true) {
-        let tempSfdxFolder = path.join(jobInfo.tempFolder, 'tempDeployLWC', 'salesforce_sfdx');
         
-        if(fs.existsSync(tempSfdxFolder)){
+        if(fs.existsSync(tempSfdxLwcFolder)){
             VlocityUtils.log('Deploying generated LWC components');
             let tempDeployOptions = {
-                sourcepath: tempSfdxFolder,
+                sourcepath: tempSfdxLwcFolder,
                 targetusername: this.vlocity.sfdxUsername
             };
 
             // Ensure there is a sfdx-project.json file
-            this.vlocity.datapacksutils.getSFDXProject({...jobInfo, sfdxForcePath: tempSfdxFolder});
+            this.vlocity.datapacksutils.getSFDXProject({...jobInfo, sfdxForcePath: tempSfdxLwcFolder});
 
             // Deploy using sfdx
             const deployGeneratedLwcFolder = await this.vlocity.utilityservice.sfdx('source:deploy', tempDeployOptions);

--- a/lib/datapacktypes/omniscript.js
+++ b/lib/datapacktypes/omniscript.js
@@ -195,17 +195,22 @@ OmniScript.prototype.compileOmniScriptLwc = async function (jobInfo, omniScriptI
 
     try {
 
-        const compilerName = 'omniscript-lwc-compiler',
-            namespace = this.vlocity.namespace,
-            packageVersion = this.vlocity.PackageVersion,
-            instanceUrl = this.vlocity.jsForceConnection.instanceUrl,
-            accessToken = this.vlocity.jsForceConnection.accessToken,
-            isDeveloperOrg = packageVersion === 'DeveloperOrg';
+        // Make sure we load the package version
+        await this.vlocity.utilityservice.getPackageVersion();
 
+        const compilerName = 'omniscript-lwc-compiler';
+        const namespace = this.vlocity.namespace;
+        const packageVersion = this.vlocity.PackageVersion;
+        const instanceUrl = this.vlocity.jsForceConnection.instanceUrl;
+        const accessToken = this.vlocity.jsForceConnection.accessToken;
+        const isDeveloperOrg = packageVersion === 'DeveloperOrg';
+
+        // Load the compiler
         const omniscriptCompiler = await VlocityUtils.loadCompiler(compilerName, jobInfo, packageVersion, namespace);
 
         // If we were unable to load the compiler package, use the legacy method
         if (!omniscriptCompiler) {
+            VlocityUtils.report('Deploying OmniScript using legacy method.');
             await this.compileOSLWC(jobInfo, omniScriptId, omniScriptKey);
             return;
         }

--- a/lib/datapacktypes/vlocitycard.js
+++ b/lib/datapacktypes/vlocitycard.js
@@ -159,11 +159,15 @@ VlocityCard.prototype.onDeployFinish = async function(jobInfo) {
             let idsArray = Object.keys(jobInfo.flexCardsToCompile);
             if (idsArray.length < 1){ 
                 return;
-            }  
+            }
+            
             //--------Load Flexcard compiler-------
-            const  compilerName = 'flexcard-compiler';
-            const  namespace = this.vlocity.namespace;
-            const  packageVersion = this.vlocity.PackageVersion;   
+            // Make sure we load the package version
+            await this.vlocity.utilityservice.getPackageVersion();
+
+            const compilerName = 'flexcard-compiler';
+            const namespace = this.vlocity.namespace;
+            const packageVersion = this.vlocity.PackageVersion;   
 
             const flexCardsCompiler = await VlocityUtils.loadCompiler(compilerName,
                                             jobInfo, packageVersion, namespace);
@@ -171,7 +175,6 @@ VlocityCard.prototype.onDeployFinish = async function(jobInfo) {
                 for (let i = 0; i < idsArray.length; i++) { 
                     let flexCardID = idsArray[i];
                     await this.compileFlexCardsLwc(flexCardID,jobInfo,flexCardsCompiler) ;
-                
                 } 
             } else{
                 hasFlexCardCompiler= false;
@@ -179,8 +182,9 @@ VlocityCard.prototype.onDeployFinish = async function(jobInfo) {
 
         } catch (e) {
             hasFlexCardCompiler= false;
-            VlocityUtils.error('Error while loading  Flexcard Compiler',e);
+            VlocityUtils.error('Error while loading Flexcard Compiler', e);
         }
+
          // If we were unable to load the compiler package, use the legacy method
         if(!hasFlexCardCompiler){
             await this.flexCardDeployWithPuppeteer(jobInfo) ;

--- a/lib/vlocityutils.js
+++ b/lib/vlocityutils.js
@@ -218,6 +218,13 @@ VlocityUtils.loadCompiler = async function (nameOfCompiler, jobInfo, packageVers
         VlocityUtils.warn('Provided compiler version does match package version.');
     }
 
+    // Make sure we have a compiler
+    if(!lwcCompilerVersion) {
+        return null;
+    }
+
+    VlocityUtils.report(`Loading ${lwcCompiler}@${lwcCompilerVersion}`);
+
     try {
         return await VlocityUtils.requirePlugin(jobInfo, lwcCompiler, lwcCompilerVersion);
     } catch (err) {


### PR DESCRIPTION
This PR solves an issue where previously deployed LWC components are not removed before starting the datapack import jobs.