### PR TITLE
Change Job Option from httpProxy to puppeteerHttpProxy

### DIFF
--- a/lib/utilityservice.js
+++ b/lib/utilityservice.js
@@ -1510,8 +1510,8 @@ UtilityService.prototype.getPuppeteerOptions = async function (jobInfo) {
         headless: jobInfo.puppeteerHeadless,
         args: ['--no-sandbox']
     };
-    if (jobInfo.httpProxy) {
-        puppeteerOptions.args.push('--proxy-server=' + jobInfo.httpProxy);
+    if (jobInfo.puppeteerHttpProxy) {
+        puppeteerOptions.args.push('--proxy-server=' + jobInfo.puppeteerHttpProxy);
     }
 
     let macChrome = path.join('/', 'Applications', 'Google Chrome.app', 'Contents', 'MacOS', 'Google Chrome');

--- a/lib/vlocitycli.js
+++ b/lib/vlocitycli.js
@@ -104,7 +104,8 @@ var VLOCITY_COMMANDLINE_OPTIONS = {
     "loginTimeoutForLoginLWC": Number,
     "puppeteerHeadless": Boolean,
     "ignoreLWCActivationOS": Boolean,
-    "ignoreLWCActivationCards": Boolean
+    "ignoreLWCActivationCards": Boolean,
+    "puppeteerHttpProxy": String
 };
 
 var VLOCITY_COMMANDLINE_OPTIONS_SHORTHAND = {


### PR DESCRIPTION
Change Job Option from httpProxy to puppeteerHttpProxy to avoid confusion with sf.httpProxy and also include it in VLOCITY_COMMANDLINE_OPTIONS