### PR TITLE
Adding the DataLong Field in the Calculation Matrix/matrix Version requests

### DIFF
--- a/lib/datapacktypes/calculationmatrix.js
+++ b/lib/datapacktypes/calculationmatrix.js
@@ -36,6 +36,10 @@ CalculationMatrix.prototype.extractAllBulkRecords = function(input) {
                                             tempData['%vlocity_namespace%__OutputData__c'] = '';
                                         }
 
+                                        if (!calcObj.hasOwnProperty("%vlocity_namespace%__OutputDataLong__c")) {
+                                            tempData['%vlocity_namespace%__OutputDataLong__c'] = '';
+                                        }
+
                                         if (tempData.Name== 'Header') {
                                             calculationMatrixHeaders.push(tempData);
                                         } else {

--- a/lib/datapacktypes/calculationmatrixversion.js
+++ b/lib/datapacktypes/calculationmatrixversion.js
@@ -47,6 +47,10 @@ CalculationMatrixVersion.prototype.extractAllBulkRecords = async function (input
 								tempData[`${dataPrefix}OutputData__c`] = '';
 							}
 
+							if (!calcObj.hasOwnProperty(`${dataPrefix}OutputDataLong__c`)) {
+								tempData[`${dataPrefix}OutputDataLong__c`] = '';
+							}
+
 							if (tempData.Name == 'Header') {
 								calculationMatrixHeaders.push(tempData);
 							} else {


### PR DESCRIPTION
Previously the matrix deployment was failing because the OutputDataLong field was not included in the request of the Matrix bulk Load(OutputData field is anyways empty in such cases). Now as the field is  OutputDataLong field is included, the CalculationMatrix insertion happens successfully for the matrices

<img width="1132" alt="Screenshot 2022-05-09 at 12 42 27 PM" src="https://user-images.githubusercontent.com/48595832/167358600-882dffc5-b1a0-4351-8226-fa27510a709c.png">

