### PR TITLE
Added the Id in the query as that would be used while updating the custom setting

### DIFF
--- a/lib/utilityservice.js
+++ b/lib/utilityservice.js
@@ -770,7 +770,7 @@ UtilityService.prototype.setVlocitySetting = async function(settingName, value) 
         if (this.vlocity.isOmniStudioInstalled) {
             result = await this.vlocity.jsForceConnection.query(`Select Value, id from OmniInteractionConfig where DeveloperName = '${settingName}'`);
         } else {
-            result = await this.vlocity.jsForceConnection.query(`Select ${this.vlocity.namespacePrefix}Value__c from ${this.vlocity.namespacePrefix}GeneralSettings__c where Name = '${settingName}'`);
+            result = await this.vlocity.jsForceConnection.query(`Select id,${this.vlocity.namespacePrefix}Value__c from ${this.vlocity.namespacePrefix}GeneralSettings__c where Name = '${settingName}'`);
         }
 
         var settingsRecord = {};


### PR DESCRIPTION
As the ID was missing, the logic was trying to insert the custom setting instead of updating and failing with the below error:
"There is already an item in this list with the name VBTDeployKey".
