### PR TITLE
W-11238262 Not activating latest Parent OS version for Reusable OS

### DIFF
--- a/lib/datapacktypes/omniscript.js
+++ b/lib/datapacktypes/omniscript.js
@@ -104,13 +104,13 @@ OmniScript.prototype.deactivateOmniScript = async function (omniscriptID) {
     try {
         var result = await this.vlocity.jsForceConnection.sobject(osAPIName).update(toUpdate);
         if (!result.success) {
-            VlocityUtils.error('Deactivating OmniScript', 'Id: ' + omniscriptID + ' Unable to deactivate OmniScript. OmniScript is still activated.');
+            VlocityUtils.error('Deactivating OmniScript ', 'Id: ' + omniscriptID + ' Unable to deactivate OmniScript. OmniScript is still activated.');
         }
         else {
-            VlocityUtils.log('Deactivating OmniScript', omniscriptID, 'OmniScript was deactivated');
+            VlocityUtils.log('Deactivating OmniScript ', omniscriptID, 'OmniScript was deactivated');
         }
     } catch (error) {
-        VlocityUtils.error('Deactivating OmniScript', 'Id: ' + omniscriptID + 'Unable to deactivate OmniScript. OmniScript is still activated - ' + error);
+        VlocityUtils.error('Deactivating OmniScript ', 'Id: ' + omniscriptID + ' Unable to deactivate OmniScript. OmniScript is still activated - ' + error);
     }
 }
 
@@ -145,7 +145,7 @@ OmniScript.prototype.afterActivationSuccess = async function (inputMap) {
             return;
         }
 
-        if (!dataPack.VlocityDataPackData[this.osObjMap(defaultNS)][0][this.osFieldMap(defaultNS + 'IsReusable__c')] && jobInfo.resusableOSToCompile && jobInfo.resusableOSToCompile[omniScriptId]) {
+        if (!dataPack.VlocityDataPackData[this.osObjMap(defaultNS)][0][this.osFieldMap(defaultNS + 'IsReusable__c')] && jobInfo.resusableOSToCompile && jobInfo.resusableOSToCompile[omniScriptKey]) {
             VlocityUtils.report(omniScriptKey, 'This OmniScipt will be compiled at the end');
             return;
         }
@@ -160,13 +160,29 @@ OmniScript.prototype.afterActivationSuccess = async function (inputMap) {
             if (!jobInfo.resusableOSToCompile) {
                 jobInfo.resusableOSToCompile = {};
             }
-            var omniScriptDataPack = dataPack.VlocityDataPackData[this.osObjMap(defaultNS)][0];
-            var searchKey = `${omniScriptDataPack[this.osFieldMap('%vlocity_namespace%__Type__c')]}|${omniScriptDataPack[this.osFieldMap('%vlocity_namespace%__SubType__c')]}|${omniScriptDataPack[this.osFieldMap('%vlocity_namespace%__Language__c')]}`;
-            let reusableOmnis = await this.vlocity.jsForceConnection.query(this.vlocity.omnistudio.updateQuery(`SELECT Id, ${this.vlocity.namespacePrefix}OmniScriptId__c FROM ${this.vlocity.namespacePrefix}Element__c WHERE ${this.vlocity.namespacePrefix}SearchKey__c = '${searchKey}' AND ${this.vlocity.namespacePrefix}OmniScriptId__r.${this.vlocity.namespacePrefix}IsActive__c = true`));
+            let nsPrefix = this.vlocity.namespacePrefix;
+            let omniScriptDataPack = dataPack.VlocityDataPackData[this.osObjMap(defaultNS)][0];
+            let searchKey = `${omniScriptDataPack[this.osFieldMap('%vlocity_namespace%__Type__c')]}|${omniScriptDataPack[this.osFieldMap('%vlocity_namespace%__SubType__c')]}|${omniScriptDataPack[this.osFieldMap('%vlocity_namespace%__Language__c')]}`;
+            let reusableOmnis = await this.vlocity.jsForceConnection.query(
+                                    this.vlocity.omnistudio.updateQuery(`SELECT Id, 
+                                                                                ${nsPrefix}OmniScriptId__c, 
+                                                                                ${nsPrefix}OmniScriptId__r.${nsPrefix}Type__c, 
+                                                                                ${nsPrefix}OmniScriptId__r.${nsPrefix}SubType__c, 
+                                                                                ${nsPrefix}OmniScriptId__r.${nsPrefix}Language__c 
+                                                                        FROM ${nsPrefix}Element__c 
+                                                                        WHERE ${nsPrefix}SearchKey__c = '${searchKey}' AND ${nsPrefix}OmniScriptId__r.${nsPrefix}IsActive__c = true`
+                                    )
+                                );
             for (var i = 0; i < reusableOmnis.records.length; i++) {
-                var omniScripToCompileId = reusableOmnis.records[i][`${this.vlocity.namespacePrefix}OmniScriptId__c`] || reusableOmnis.records[i]['OmniProcessId'];
-                VlocityUtils.log('Parent OmniScript for Reusable OmniScript will be compiled at the end', omniScriptKey);
-                jobInfo.resusableOSToCompile[omniScripToCompileId] = omniScriptKey;
+                let obj = reusableOmnis.records[i];
+                let parentOsKey = '';
+                if (obj[`${nsPrefix}OmniScriptId__r`]) {
+                    parentOsKey = `OmniScript/${ obj[`${nsPrefix}OmniScriptId__r`][`${nsPrefix}Type__c`]}_${obj[`${nsPrefix}OmniScriptId__r`][`${nsPrefix}SubType__c`]}_${ obj[`${nsPrefix}OmniScriptId__r`][`${nsPrefix}Language__c`]}`;
+                } else {
+                    parentOsKey = `OmniScript/${obj.OmniProcess.Type}_${obj.OmniProcess.SubType}_${obj.OmniProcess.Language}`;
+                }
+                VlocityUtils.log(`Parent OmniScript (${parentOsKey}) for Reusable OmniScript (${omniScriptKey}) will be compiled at the end`);
+                jobInfo.resusableOSToCompile[parentOsKey] = obj;
             }
         }
     }
@@ -175,8 +191,32 @@ OmniScript.prototype.afterActivationSuccess = async function (inputMap) {
 
 OmniScript.prototype.onDeployFinish = async function (jobInfo) {
     if (jobInfo.resusableOSToCompile) {
-        VlocityUtils.verbose('Parent OmniScripts to Compile', jobInfo.resusableOSToCompile);
-        var idsArray = Object.keys(jobInfo.resusableOSToCompile);
+        let omniscriptIdToKeyMap = {};
+        var osKeysArray = Object.keys(jobInfo.resusableOSToCompile);
+        VlocityUtils.verbose('Parent OmniScripts to Compile', osKeysArray);
+        
+        for(let key of osKeysArray) {
+            let nsPrefix = this.vlocity.namespacePrefix,
+                omniScript = jobInfo.resusableOSToCompile[key],
+                query = '';
+
+            if(omniScript[`${nsPrefix}OmniScriptId__r`]) {
+                let type = omniScript[`${nsPrefix}OmniScriptId__r`][`${nsPrefix}Type__c`];
+                let subType = omniScript[`${nsPrefix}OmniScriptId__r`][`${nsPrefix}SubType__c`];
+                let lang = omniScript[`${nsPrefix}OmniScriptId__r`][`${nsPrefix}Language__c`];
+                query = this.vlocity.omnistudio.updateQuery(`SELECT Id FROM ${nsPrefix}OmniScript__c WHERE ${nsPrefix}Type__c = '${type}' AND ${nsPrefix}SubType__c = '${subType}' AND ${nsPrefix}Language__c = '${lang}' AND ${nsPrefix}IsActive__c = true`);
+            } else {
+                query = this.vlocity.omnistudio.updateQuery(`SELECT Id FROM ${nsPrefix}OmniScript__c WHERE ${nsPrefix}Type__c = '${omniScript.OmniProcess.Type}' AND ${nsPrefix}SubType__c = '${omniScript.OmniProcess.SubType}' AND ${nsPrefix}Language__c = '${omniScript.OmniProcess.Language}' AND ${nsPrefix}IsActive__c = true`);
+            }
+
+            let parentOmniScript = await this.vlocity.jsForceConnection.query(query);
+            omniscriptIdToKeyMap[parentOmniScript.records[0].Id] = key;
+        }
+
+        jobInfo.resusableOSToCompile = Object.assign({},omniscriptIdToKeyMap);
+        
+        let idsArray = Object.keys(jobInfo.resusableOSToCompile);
+        
         // To handle the Retry in the case of only manifest error as that prints unwanted json
         if (idsArray.length < 1) {
             return;


### PR DESCRIPTION
While activating the Reusable OmniScripts, it queries for parent OmniScript. But at this time, the Parent OS is still not deployed, So previous version which is activated at this time is retrieved and is being kept for post-deployment activation rather than taking latest deployed version. 

Also logs were not showing the correct info.

<img width="1358" alt="Screenshot 2022-06-02 at 11 42 23 AM" src="https://user-images.githubusercontent.com/86437068/172185353-bbd973c2-4ca5-494a-a0dc-ae1014725639.png">

