### PR TITLE
Fixes an issue with exporting Products, etc with hyphens.

### DIFF
--- a/lib/datapacksexpand.js
+++ b/lib/datapacksexpand.js
@@ -31,6 +31,10 @@ DataPacksExpand.generateFolderOrFilename = function(filename, extension) {
         .replace(/^[-_\\/]+/, "")
         .replace(/[-_\\/]+$/, "");
 
+    if (sanitizedFilename == '') {
+        sanitizedFilename = 'MissingName';
+    }
+
     let basename = path.basename(sanitizedFilename);
     
     if (basename.length > MAX_FILE_LENGTH) {


### PR DESCRIPTION
This fixes an issue with exporting a String Translation (and possibly other items), where the Name is a single hyphen. The data sanitization removes the hyphen, leaving the resulting folder name as an empty string, and breaking the export. This ensures that if the sanitization removes the full string, that there is a replacement.