### PR TITLE
Ignore the local compilation of FlexCards for LWC Activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,7 +775,7 @@ The Job file additionally supports some Vlocity Build based options and the opti
 ## Job Options 
 | Option | Description | Type  | Default |
 | ------------- |------------- |----- | -----|
-| activate | Will Activate everything after it is imported / deployed | Boolean | false |
+| activate | Will Activate everything after it is imported / deployed | Boolean | true |
 | addSourceKeys | Generate Global / Unique Keys for Records that are missing this data. Improves ability to import exported data | Boolean | false |
 | autoFixPicklists | Makes metadata changes across orgs for Vlocity Managed Package fields automatically propagate and eliminates errors due to this missing metadata. Does not work for Managed Global Value Sets - Like Vlocity's CurrencyCode field. | Boolean | true |
 | autoRetryErrors | Will automatically retry after a deploy to see if any errors can be fixed by retrying due primarily to references that did not correctly resolve | Boolean | false |
@@ -1036,6 +1036,7 @@ These types are what would be specified when creating a Query or Manifest for th
 | DocumentTemplate | DocumentTemplate__c<br>DocumentTemplateSection__c<br>DocumentTemplateSectionCondition__c |
 | EntityFilter | EntityFilter__c<br>EntityFilterCondition__c<br>EntityFilterMember__c<br>EntityFilterConditionArgument__c |
 | IntegrationProcedure | OmniScript__c<br>Element__c |
+| IntegrationRetryPolicy | IntegrationRetryPolicy__c |
 | InterfaceImplementation | InterfaceImplementation__c<br>InterfaceImplementationDetail__c |
 | ItemImplementation | ItemImplementation__c |
 | ManualQueue | ManualQueue__c |

--- a/README.md
+++ b/README.md
@@ -396,6 +396,12 @@ ignoreLWCActivationCards: true
 
 Otherwise these are now on by default.
 
+To disable the local compilation of the FlexCards so that the npmAuthKey is used only for the local compilation of OmniScript. In this case legacy method would be used for the FlexCard LWC activation:
+
+``` 
+ignoreLocalCompilationCards: true
+```
+
 In cases where there is a specific executable path for Chrome, or there is no interest in the use of its headless feature, it is possible to do as follows: 
 ```
 puppeteerHeadless: false

--- a/lib/datapacktypes/flexcard.js
+++ b/lib/datapacktypes/flexcard.js
@@ -160,26 +160,28 @@ FlexCard.prototype.onDeployFinish = async function(jobInfo) {
             if (idsArray.length < 1){ 
                 return;
             }
-            
-            //--------Load Flexcard compiler-------
-            // Make sure we load the package version
-            await this.vlocity.utilityservice.getPackageVersion();
-
-            const compilerName = 'flexcard-compiler';
-            const namespace = this.vlocity.namespace;
-            const packageVersion = this.vlocity.PackageVersion;   
-
-            const flexCardsCompiler = await VlocityUtils.loadCompiler(compilerName,
-                                            jobInfo, packageVersion, namespace);
-            if(flexCardsCompiler){
-                for (let i = 0; i < idsArray.length; i++) { 
-                    let flexCardID = idsArray[i];
-                    await this.compileFlexCardsLwc(flexCardID,jobInfo,flexCardsCompiler) ;
-                } 
+            if (!jobInfo.ignoreLocalCompilationCards){
+                //--------Load Flexcard compiler-------
+                // Make sure we load the package version
+                await this.vlocity.utilityservice.getPackageVersion();
+    
+                const compilerName = 'flexcard-compiler';
+                const namespace = this.vlocity.namespace;
+                const packageVersion = this.vlocity.PackageVersion;   
+    
+                const flexCardsCompiler = await VlocityUtils.loadCompiler(compilerName,
+                                                jobInfo, packageVersion, namespace);
+                if(flexCardsCompiler){
+                    for (let i = 0; i < idsArray.length; i++) { 
+                        let flexCardID = idsArray[i];
+                        await this.compileFlexCardsLwc(flexCardID,jobInfo,flexCardsCompiler) ;
+                    } 
+                } else{
+                    hasFlexCardCompiler= false;
+                }
             } else{
-                hasFlexCardCompiler= false;
-            }
-
+                    hasFlexCardCompiler= false;
+            }        
         } catch (e) {
             hasFlexCardCompiler= false;
             VlocityUtils.error('Error while loading Flexcard Compiler', e);

--- a/lib/vlocitycli.js
+++ b/lib/vlocitycli.js
@@ -106,6 +106,7 @@ var VLOCITY_COMMANDLINE_OPTIONS = {
     "puppeteerHeadless": Boolean,
     "ignoreLWCActivationOS": Boolean,
     "ignoreLWCActivationCards": Boolean,
+    "ignoreLocalCompilationCards": Boolean,
     "puppeteerHttpProxy": String,
     "overrideOrgCommit": String
 };


### PR DESCRIPTION
Changes to ignore the local compilation of FlexCards when npmAuthKey is used in the job file.