### PR TITLE
OverrideDefinition and CompiledAttributeOverride to be removed during pagination

### DIFF
--- a/lib/datapacksexpanddefinition.yaml
+++ b/lib/datapacksexpanddefinition.yaml
@@ -137,7 +137,9 @@ DataPacks:
       AttributeAssignment__c:
         - RemoveFromInitial
       OverrideDefinition__c:
-        - RemoveFromInitial
+        - Remove
+      CompiledAttributeOverride__c:
+        - Remove
   ProductChildItem:
     ProductChildItem__c:
       FolderName:


### PR DESCRIPTION
OverrideDefinition and CompiledAttributeOverride to be removed during pagination as currently it gets duplicated in the target org. As there is no matching key for these objects and hence these records are inserted multiple times.