### PR TITLE
Process the manifest Items all together instead of importing them in batches(as its failing)

### DIFF
--- a/lib/datapacksjob.js
+++ b/lib/datapacksjob.js
@@ -3726,6 +3726,9 @@ DataPacksJob.prototype.convertToCore = async function (jobInfo) {
 }
 
 DataPacksJob.prototype.validateParentKeys = async function (jobInfo) {
+    jobInfo.singleFile = true;
+    jobInfo.disablePagination = true;
+    jobInfo.compileOnBuild = false;    
     let dataJSON = await this.vlocity.datapacksbuilder.buildImport(jobInfo.projectPath, jobInfo);
     this.vlocity.datapacksexpand.targetPath = path.join(jobInfo.projectPath, jobInfo.expansionPath);
     for (var dataPack of dataJSON.dataPacks) {


### PR DESCRIPTION
Process the datapacks to generate the ParentKeys.json files