### PR TITLE
@W-21600617 Fixing npm audit vulnerabilities

### DIFF
--- a/.cloudbees/workflows/publish-pipeline.yaml
+++ b/.cloudbees/workflows/publish-pipeline.yaml
@@ -13,48 +13,49 @@ jobs:
   # =============================================================================
   # TEST JOB - Must pass before publish runs
   # =============================================================================
-  # test:
-  #   steps:
-  #     - name: Checkout Code
-  #       uses: cloudbees-io/checkout@v1
+  test:
+    steps:
+      - name: Checkout Code
+        uses: cloudbees-io/checkout@v1
 
-  #     - name: Run Tests
-  #       uses: docker://node:18
-  #       env:
-  #         SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL }}
-  #       run: |
-  #         echo "=== Installing jq and SF CLI ==="
-  #         apt-get update && apt-get install -y jq
-  #         npm install -g @salesforce/cli
-  #         sf --version
+      - name: Run Tests
+        uses: docker://node:18
+        env:
+          SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL }}
+        run: |
+          echo "=== Installing jq and SF CLI ==="
+          apt-get update && apt-get install -y jq
+          npm install -g @salesforce/cli
+          sf --version
           
-  #         echo "=== Authenticating to Salesforce ==="
-  #         SF_USERNAME=$(echo "$SFDX_AUTH_URL" | sf org login sfdx-url --sfdx-url-file /dev/stdin --json 2>/dev/null | jq -r '.result.username')
-  #         echo "Authenticated as: $SF_USERNAME"
+          echo "=== Authenticating to Salesforce ==="
+          SF_USERNAME=$(echo "$SFDX_AUTH_URL" | sf org login sfdx-url --sfdx-url-file /dev/stdin --json 2>/dev/null | jq -r '.result.username')
+          echo "Authenticated as: $SF_USERNAME"
           
-  #         echo "=== Installing dependencies ==="
-  #         npm install
+          echo "=== Installing dependencies ==="
+          npm install
           
-  #         echo "=== Running Unit Tests ==="
-  #         npm run-script unitTest
+          echo "=== Running Unit Tests ==="
+          npm run-script unitTest
           
-  #         echo "=== Linking package ==="
-  #         npm link
+          echo "=== Linking package ==="
+          npm link
           
-  #         echo "=== Running Vlocity Test Job (Verbose) ==="
-  #         vlocity -sfdx.username "$SF_USERNAME" runTestJob --verbose
+          echo "=== Running Vlocity Test Job (Verbose) ==="
+          vlocity -sfdx.username "$SF_USERNAME" runTestJob --verbose
           
-  #         echo "=== Running Vlocity Test Job (JSON) ==="
-  #         vlocity -sfdx.username "$SF_USERNAME" runTestJob --json | jq .
+          echo "=== Running Vlocity Test Job (JSON) ==="
+          vlocity -sfdx.username "$SF_USERNAME" runTestJob --json | jq .
           
-  #         echo "=========================================="
-  #         echo "TEST PIPELINE - PASSED"
-  #         echo "=========================================="
+          echo "=========================================="
+          echo "TEST PIPELINE - PASSED"
+          echo "=========================================="
 
   # =============================================================================
   # PUBLISH JOB - Only runs if test job passes (needs: test)
   # =============================================================================
   publish:
+    needs: test
     steps:
       - name: Checkout Code
         uses: cloudbees-io/checkout@v1

--- a/.cloudbees/workflows/publish-pipeline.yaml
+++ b/.cloudbees/workflows/publish-pipeline.yaml
@@ -22,6 +22,8 @@ jobs:
         uses: docker://node:18
         env:
           SFDX_AUTH_URL: ${{ vars.SFDX_AUTH_URL }}
+          SF_DISABLE_TELEMETRY: "true"
+          SFDX_DISABLE_TELEMETRY: "true"
         run: |
           echo "=== Installing jq and SF CLI ==="
           apt-get update && apt-get install -y jq

--- a/.cloudbees/workflows/publish-pipeline.yaml
+++ b/.cloudbees/workflows/publish-pipeline.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Run Tests
         uses: docker://node:18
         env:
-          SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL }}
+          SFDX_AUTH_URL: ${{ env.SFDX_AUTH_URL }}
         run: |
           echo "=== Installing jq and SF CLI ==="
           apt-get update && apt-get install -y jq

--- a/.cloudbees/workflows/publish-pipeline.yaml
+++ b/.cloudbees/workflows/publish-pipeline.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Run Tests
         uses: docker://node:18
         env:
-          SFDX_AUTH_URL: ${{ env.SFDX_AUTH_URL }}
+          SFDX_AUTH_URL: ${{ vars.SFDX_AUTH_URL }}
         run: |
           echo "=== Installing jq and SF CLI ==="
           apt-get update && apt-get install -y jq

--- a/.cloudbees/workflows/publish-pipeline.yaml
+++ b/.cloudbees/workflows/publish-pipeline.yaml
@@ -29,7 +29,24 @@ jobs:
           sf --version
           
           echo "=== Authenticating to Salesforce ==="
-          SF_USERNAME=$(echo "$SFDX_AUTH_URL" | sf org login sfdx-url --sfdx-url-file /dev/stdin --json 2>/dev/null | jq -r '.result.username')
+          if [ -z "$SFDX_AUTH_URL" ]; then
+            echo "ERROR: SFDX_AUTH_URL is empty. Please set vars.SFDX_AUTH_URL in CloudBees."
+            exit 1
+          fi
+          echo "$SFDX_AUTH_URL" > /tmp/sfdx_auth_url.txt
+          LOGIN_RESULT=$(sf org login sfdx-url --sfdx-url-file /tmp/sfdx_auth_url.txt --json)
+          LOGIN_EXIT=$?
+          rm -f /tmp/sfdx_auth_url.txt
+          echo "Login result: $LOGIN_RESULT"
+          if [ $LOGIN_EXIT -ne 0 ]; then
+            echo "ERROR: sf org login failed with exit code $LOGIN_EXIT"
+            exit 1
+          fi
+          SF_USERNAME=$(echo "$LOGIN_RESULT" | jq -r '.result.username')
+          if [ -z "$SF_USERNAME" ] || [ "$SF_USERNAME" == "null" ]; then
+            echo "ERROR: Failed to extract username from SFDX login."
+            exit 1
+          fi
           echo "Authenticated as: $SF_USERNAME"
           
           echo "=== Installing dependencies ==="

--- a/.cloudbees/workflows/test-pipeline.yaml
+++ b/.cloudbees/workflows/test-pipeline.yaml
@@ -34,7 +34,17 @@ jobs:
           sf --version
           
           echo "=== Authenticating to Salesforce ==="
-          SF_USERNAME=$(echo "$SFDX_AUTH_URL" | sf org login sfdx-url --sfdx-url-file /dev/stdin --json 2>/dev/null | jq -r '.result.username')
+          if [ -z "$SFDX_AUTH_URL" ]; then
+            echo "ERROR: SFDX_AUTH_URL is empty. Please set vars.SFDX_AUTH_URL in CloudBees."
+            exit 1
+          fi
+          LOGIN_RESULT=$(echo "$SFDX_AUTH_URL" | sf org login sfdx-url --sfdx-url-file /dev/stdin --json 2>&1)
+          echo "Login result: $LOGIN_RESULT"
+          SF_USERNAME=$(echo "$LOGIN_RESULT" | jq -r '.result.username')
+          if [ -z "$SF_USERNAME" ] || [ "$SF_USERNAME" == "null" ]; then
+            echo "ERROR: Failed to extract username from SFDX login."
+            exit 1
+          fi
           echo "Authenticated as: $SF_USERNAME"
           
           echo "=== Installing dependencies ==="

--- a/.cloudbees/workflows/test-pipeline.yaml
+++ b/.cloudbees/workflows/test-pipeline.yaml
@@ -38,8 +38,15 @@ jobs:
             echo "ERROR: SFDX_AUTH_URL is empty. Please set vars.SFDX_AUTH_URL in CloudBees."
             exit 1
           fi
-          LOGIN_RESULT=$(echo "$SFDX_AUTH_URL" | sf org login sfdx-url --sfdx-url-file /dev/stdin --json 2>&1)
+          echo "$SFDX_AUTH_URL" > /tmp/sfdx_auth_url.txt
+          LOGIN_RESULT=$(sf org login sfdx-url --sfdx-url-file /tmp/sfdx_auth_url.txt --json)
+          LOGIN_EXIT=$?
+          rm -f /tmp/sfdx_auth_url.txt
           echo "Login result: $LOGIN_RESULT"
+          if [ $LOGIN_EXIT -ne 0 ]; then
+            echo "ERROR: sf org login failed with exit code $LOGIN_EXIT"
+            exit 1
+          fi
           SF_USERNAME=$(echo "$LOGIN_RESULT" | jq -r '.result.username')
           if [ -z "$SF_USERNAME" ] || [ "$SF_USERNAME" == "null" ]; then
             echo "ERROR: Failed to extract username from SFDX login."

--- a/.cloudbees/workflows/test-pipeline.yaml
+++ b/.cloudbees/workflows/test-pipeline.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Run Tests
         uses: docker://node:18
         env:
-          SFDX_AUTH_URL: ${{ env.SFDX_AUTH_URL }}
+          SFDX_AUTH_URL: ${{ vars.SFDX_AUTH_URL }}
         run: |
           echo "=== Installing jq and SF CLI ==="
           apt-get update && apt-get install -y jq

--- a/.cloudbees/workflows/test-pipeline.yaml
+++ b/.cloudbees/workflows/test-pipeline.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Run Tests
         uses: docker://node:18
         env:
-          SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL }}
+          SFDX_AUTH_URL: ${{ env.SFDX_AUTH_URL }}
         run: |
           echo "=== Installing jq and SF CLI ==="
           apt-get update && apt-get install -y jq

--- a/.cloudbees/workflows/test-pipeline.yaml
+++ b/.cloudbees/workflows/test-pipeline.yaml
@@ -27,6 +27,8 @@ jobs:
         uses: docker://node:18
         env:
           SFDX_AUTH_URL: ${{ vars.SFDX_AUTH_URL }}
+          SF_DISABLE_TELEMETRY: "true"
+          SFDX_DISABLE_TELEMETRY: "true"
         run: |
           echo "=== Installing jq and SF CLI ==="
           apt-get update && apt-get install -y jq

--- a/lib/datapacksutils.js
+++ b/lib/datapacksutils.js
@@ -5,10 +5,8 @@ var stringify_pretty = require('json-stable-stringify');
 var yaml = require('js-yaml');
 var gitDiff = require('git-diff');
 var ignore = require( 'ignore');
-const fileType = require('file-type');
 const isUtf8 = require('is-utf8');
 const UtilityService = require('./utilityservice.js');
-var filterxml = require('filterxml');
 var xml2js = require('xml2js');
 var xmlbuilder = require('xmlbuilder');
 const csvParser = require('json2csv');
@@ -3778,28 +3776,34 @@ DataPacksUtils.prototype.filterInvalidLayouts = function(currentArray, layoutNam
 }
 
 DataPacksUtils.prototype.removeInvalidXMLNodes = async function(file) {
-    return new Promise(resolve => { 
-        if (file.indexOf('-meta.xml') != -1) {
-            var fileData = fs.readFileSync(file, { encoding: 'utf8' });
+    if (file.indexOf('-meta.xml') === -1) {
+        return;
+    }
 
-            if (fileData == '<?xml version="1.0" encoding="UTF-8"?>') {
-                return resolve();
-            }
+    var fileData = fs.readFileSync(file, { encoding: 'utf8' });
 
-            var patterns = [ '//xmlns:packageVersions' ];
-            var namespaces = { xmlns: "http://soap.sforce.com/2006/04/metadata" };
+    if (fileData === '<?xml version="1.0" encoding="UTF-8"?>') {
+        return;
+    }
 
-            filterxml(fileData, patterns, namespaces, function (err, xmlOut) {
-                if (fileData != xmlOut) {
-                    fs.outputFileSync(file, xmlOut, { encoding: 'utf8' });
-                }
-                
-                resolve();
-            });
-        } else {
-            resolve();
+    var parser = new xml2js.Parser();
+    var result = await parser.parseStringPromise(fileData);
+
+    if (!result) {
+        return;
+    }
+
+    var rootKey = Object.keys(result)[0];
+    var root = result[rootKey];
+
+    if (root && root.packageVersions) {
+        delete root.packageVersions;
+        var builder = new xml2js.Builder({ xmldec: { version: '1.0', encoding: 'UTF-8' } });
+        var xmlOut = builder.buildObject(result);
+        if (fileData !== xmlOut) {
+            fs.outputFileSync(file, xmlOut, { encoding: 'utf8' });
         }
-    });
+    }
 }
 
 DataPacksUtils.prototype.getLayoutsFromToolingAPI = async function(objectType, allSFDXFileNames) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,7 @@
             "dependencies": {
                 "async": "3.2.5",
                 "command-exists": "^1.2.9",
-                "diff2html": "2.5.0",
                 "fast-json-stable-stringify": "2.1.0",
-                "file-type": "^16.5.4",
-                "filterxml": "2.0.0",
                 "fs-extra": "8.0.1",
                 "git-diff": "2.0.6",
                 "global-modules-path": "3.0.0",
@@ -35,7 +32,7 @@
                 "sass": "^1.77.0",
                 "semver": "6.3.1",
                 "shelljs": "^0.8.5",
-                "simple-git": "3.22.0",
+                "simple-git": "^3.33.0",
                 "unidecode": "0.1.8",
                 "xml2js": "0.6.2",
                 "xmlbuilder": "13.0.2"
@@ -45,7 +42,7 @@
             },
             "devDependencies": {
                 "chai": "^4.1.2",
-                "mocha": "^10.8.2"
+                "mocha": "^11"
             },
             "engines": {
                 "node": ">=18.8.2"
@@ -91,6 +88,109 @@
                 "@types/node": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@isaacs/cliui/node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
         "node_modules/@kwsites/file-exists": {
@@ -404,6 +504,17 @@
                 "url": "https://opencollective.com/parcel"
             }
         },
+        "node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@sindresorhus/is": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -421,11 +532,6 @@
             "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.6.tgz",
             "integrity": "sha512-vL9EVn/v+OhZ+Wcs6O4iKE9EUpwHUqHmCtNUMWjqp+6dr85+XPOSGTEsqYNq1Vn04uk9SWlOVmx9J48ggJVT2Q==",
             "license": "MIT"
-        },
-        "node_modules/@tokenizer/token": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-            "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
         },
         "node_modules/@types/debug": {
             "version": "4.1.12",
@@ -517,31 +623,11 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@xmldom/xmldom": {
-            "version": "0.8.10",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-            "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/abbrev": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
             "license": "ISC"
-        },
-        "node_modules/abort-controller": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-            "dependencies": {
-                "event-target-shim": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=6.5"
-            }
         },
         "node_modules/agent-base": {
             "version": "6.0.2",
@@ -553,16 +639,6 @@
             },
             "engines": {
                 "node": ">= 6.0.0"
-            }
-        },
-        "node_modules/ansi-colors": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-            "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/ansi-escapes": {
@@ -599,20 +675,6 @@
             },
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/anymatch": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "normalize-path": "^3.0.0",
-                "picomatch": "^2.0.4"
-            },
-            "engines": {
-                "node": ">= 8"
             }
         },
         "node_modules/argparse": {
@@ -705,19 +767,6 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/binary-extensions": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-            "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/bl": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -730,9 +779,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+            "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -743,8 +792,8 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "fill-range": "^7.1.1"
             },
@@ -871,28 +920,18 @@
             }
         },
         "node_modules/chokidar": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-            "dev": true,
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
             "license": "MIT",
             "dependencies": {
-                "anymatch": "~3.1.2",
-                "braces": "~3.0.2",
-                "glob-parent": "~5.1.2",
-                "is-binary-path": "~2.1.0",
-                "is-glob": "~4.0.1",
-                "normalize-path": "~3.0.0",
-                "readdirp": "~3.6.0"
+                "readdirp": "^4.0.1"
             },
             "engines": {
-                "node": ">= 8.10.0"
+                "node": ">= 14.16.0"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.2"
             }
         },
         "node_modules/chownr": {
@@ -938,15 +977,18 @@
             }
         },
         "node_modules/cliui": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
                 "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
+                "strip-ansi": "^6.0.1",
                 "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/cliui/node_modules/ansi-styles": {
@@ -1045,15 +1087,6 @@
             "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
             "license": "MIT"
         },
-        "node_modules/commander": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 12"
-            }
-        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1080,6 +1113,21 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/core-js"
+            }
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/csprng": {
@@ -1189,30 +1237,6 @@
             "integrity": "sha512-iI3v9uuGUW02vPUXTvxl4ijnCPL/RGRVR9I+U8s7+9OG9An/bvExjQ0KrXE9V0QBLra7wANhZctB00FKBSn1gw==",
             "license": "BSD-3-Clause"
         },
-        "node_modules/diff": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
-        "node_modules/diff2html": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/diff2html/-/diff2html-2.5.0.tgz",
-            "integrity": "sha512-pnk3EpZyuQyUl7/45KrmZPYIQB/tL03xgijzzkxWqy/UAXyV5qjB+g7ce8mbdSs1G+lO4ykMgjy+7NVN4siS/A==",
-            "license": "MIT",
-            "dependencies": {
-                "diff": "^3.5.0",
-                "hogan.js": "^3.0.2",
-                "lodash": "^4.17.11",
-                "whatwg-fetch": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1226,6 +1250,13 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -1319,22 +1350,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/event-target-shim": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/events": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-            "engines": {
-                "node": ">=0.8.x"
-            }
-        },
         "node_modules/extract-zip": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -1414,50 +1429,17 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/file-type": {
-            "version": "16.5.4",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-            "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
-            "dependencies": {
-                "readable-web-to-node-stream": "^3.0.0",
-                "strtok3": "^6.2.4",
-                "token-types": "^4.1.1"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/file-type?sponsor=1"
-            }
-        },
         "node_modules/fill-range": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/filterxml": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/filterxml/-/filterxml-2.0.0.tgz",
-            "integrity": "sha512-wO/ED/SHqZ+wo5N4t0y8ilZ15zI78/3raYBV86GwOJkry91ow51JRxaFsl5XXHnrqRJ1dp+uWyAH02XqdkdRQg==",
-            "license": "MIT",
-            "dependencies": {
-                "@xmldom/xmldom": "0.8.10",
-                "commander": "^8.3.0",
-                "xpath": "^0.0.34"
-            },
-            "bin": {
-                "filterxml": "bin/filterxml.js"
-            },
-            "engines": {
-                "node": ">=12.0.0"
             }
         },
         "node_modules/find-up": {
@@ -1485,6 +1467,36 @@
             "license": "BSD-3-Clause",
             "bin": {
                 "flat": "cli.js"
+            }
+        },
+        "node_modules/foreground-child": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.6",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/foreground-child/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/form-data": {
@@ -1552,21 +1564,6 @@
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "license": "ISC"
-        },
-        "node_modules/fsevents": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
@@ -1677,38 +1674,45 @@
                 "node": ">= 4.8.0"
             }
         },
+        "node_modules/git-diff/node_modules/diff": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.1.tgz",
+            "integrity": "sha512-Z3u54A8qGyqFOSr2pk0ijYs8mOE9Qz8kTvtKeBI+upoG9j04Sq+oI7W8zAJiQybDcESET8/uIdHzs0p3k4fZlw==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
         "node_modules/glob": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
             },
-            "engines": {
-                "node": ">=12"
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+        "node_modules/glob/node_modules/minipass": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
             "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "is-glob": "^4.0.1"
-            },
+            "license": "BlueOak-1.0.0",
             "engines": {
-                "node": ">= 6"
+                "node": ">=16 || 14 >=14.17"
             }
         },
         "node_modules/global-modules-path": {
@@ -1793,33 +1797,6 @@
                 "he": "bin/he"
             }
         },
-        "node_modules/hogan.js": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
-            "integrity": "sha512-RqGs4wavGYJWE07t35JQccByczmNUXQT0E12ZYV1VKYu5UiAU9lsos/yBAcf840+zrUQQxgVduCR5/B8nNtibg==",
-            "dependencies": {
-                "mkdirp": "0.3.0",
-                "nopt": "1.0.10"
-            },
-            "bin": {
-                "hulk": "bin/hulk"
-            }
-        },
-        "node_modules/hogan.js/node_modules/nopt": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-            "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
-            "license": "MIT",
-            "dependencies": {
-                "abbrev": "1"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/http-parser-js": {
             "version": "0.5.10",
             "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
@@ -1885,9 +1862,9 @@
             }
         },
         "node_modules/immutable": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
-            "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+            "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
             "license": "MIT"
         },
         "node_modules/inflight": {
@@ -2012,19 +1989,6 @@
                 "node": ">= 0.10"
             }
         },
-        "node_modules/is-binary-path": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "binary-extensions": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/is-core-module": {
             "version": "2.16.1",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -2059,8 +2023,8 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2078,8 +2042,8 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -2100,10 +2064,20 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-path-inside": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/is-plain-obj": {
@@ -2144,6 +2118,29 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/jackspeak": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
             }
         },
         "node_modules/js-yaml": {
@@ -2279,9 +2276,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "license": "MIT"
         },
         "node_modules/lodash.get": {
@@ -2400,6 +2397,13 @@
                 "get-func-name": "^2.0.1"
             }
         },
+        "node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2454,16 +2458,19 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/minipass": {
@@ -2500,16 +2507,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/mkdirp": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-            "integrity": "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==",
-            "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-            "license": "MIT/X11",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/mkdirp-classic": {
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -2517,31 +2514,32 @@
             "license": "MIT"
         },
         "node_modules/mocha": {
-            "version": "10.8.2",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
-            "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
+            "version": "11.7.5",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
+            "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ansi-colors": "^4.1.3",
                 "browser-stdout": "^1.3.1",
-                "chokidar": "^3.5.3",
+                "chokidar": "^4.0.1",
                 "debug": "^4.3.5",
-                "diff": "^5.2.0",
+                "diff": "^7.0.0",
                 "escape-string-regexp": "^4.0.0",
                 "find-up": "^5.0.0",
-                "glob": "^8.1.0",
+                "glob": "^10.4.5",
                 "he": "^1.2.0",
+                "is-path-inside": "^3.0.3",
                 "js-yaml": "^4.1.0",
                 "log-symbols": "^4.1.0",
-                "minimatch": "^5.1.6",
+                "minimatch": "^9.0.5",
                 "ms": "^2.1.3",
+                "picocolors": "^1.1.1",
                 "serialize-javascript": "^6.0.2",
                 "strip-json-comments": "^3.1.1",
                 "supports-color": "^8.1.1",
-                "workerpool": "^6.5.1",
-                "yargs": "^16.2.0",
-                "yargs-parser": "^20.2.9",
+                "workerpool": "^9.2.0",
+                "yargs": "^17.7.2",
+                "yargs-parser": "^21.1.1",
                 "yargs-unparser": "^2.0.0"
             },
             "bin": {
@@ -2549,7 +2547,7 @@
                 "mocha": "bin/mocha.js"
             },
             "engines": {
-                "node": ">= 14.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
         "node_modules/mocha/node_modules/argparse": {
@@ -2560,9 +2558,9 @@
             "license": "Python-2.0"
         },
         "node_modules/mocha/node_modules/diff": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-            "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+            "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -2693,16 +2691,6 @@
             },
             "bin": {
                 "nopt": "bin/nopt.js"
-            }
-        },
-        "node_modules/normalize-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/once": {
@@ -2930,6 +2918,13 @@
                 "node": ">=6"
             }
         },
+        "node_modules/package-json-from-dist": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0"
+        },
         "node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2948,11 +2943,38 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "license": "MIT"
+        },
+        "node_modules/path-scurry": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/pathval": {
             "version": "1.1.1",
@@ -2964,30 +2986,25 @@
                 "node": "*"
             }
         },
-        "node_modules/peek-readable": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
-            "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Borewit"
-            }
-        },
         "node_modules/pend": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
             "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
             "license": "MIT"
         },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "devOptional": true,
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -3057,14 +3074,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/process": {
-            "version": "0.11.10",
-            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-            "engines": {
-                "node": ">= 0.6.0"
             }
         },
         "node_modules/progress": {
@@ -3139,16 +3148,6 @@
                 "node": ">=10.18.1"
             }
         },
-        "node_modules/randombytes": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "^5.1.0"
-            }
-        },
         "node_modules/readable-stream": {
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -3163,70 +3162,17 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/readable-web-to-node-stream": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
-            "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
-            "dependencies": {
-                "readable-stream": "^4.7.0"
-            },
+        "node_modules/readdirp": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+            "license": "MIT",
             "engines": {
-                "node": ">=8"
+                "node": ">= 14.18.0"
             },
             "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Borewit"
-            }
-        },
-        "node_modules/readable-web-to-node-stream/node_modules/buffer": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.2.1"
-            }
-        },
-        "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-            "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-            "dependencies": {
-                "abort-controller": "^3.0.0",
-                "buffer": "^6.0.3",
-                "events": "^3.3.0",
-                "process": "^0.11.10",
-                "string_decoder": "^1.3.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
-        "node_modules/readdirp": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "picomatch": "^2.2.1"
-            },
-            "engines": {
-                "node": ">=8.10.0"
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/rechoir": {
@@ -3300,9 +3246,9 @@
             }
         },
         "node_modules/rimraf/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -3331,9 +3277,9 @@
             }
         },
         "node_modules/rimraf/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -3475,34 +3421,6 @@
                 "@parcel/watcher": "^2.4.1"
             }
         },
-        "node_modules/sass/node_modules/chokidar": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-            "license": "MIT",
-            "dependencies": {
-                "readdirp": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 14.16.0"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/sass/node_modules/readdirp": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14.18.0"
-            },
-            "funding": {
-                "type": "individual",
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
         "node_modules/sax": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
@@ -3528,13 +3446,36 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+            "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "randombytes": "^2.1.0"
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/shelljs": {
@@ -3564,9 +3505,9 @@
             }
         },
         "node_modules/shelljs/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -3595,9 +3536,9 @@
             }
         },
         "node_modules/shelljs/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -3613,14 +3554,14 @@
             "license": "ISC"
         },
         "node_modules/simple-git": {
-            "version": "3.22.0",
-            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.22.0.tgz",
-            "integrity": "sha512-6JujwSs0ac82jkGjMHiCnTifvf1crOiY/+tfs/Pqih6iow7VrpNKRRNdWm6RtaXpvvv/JGNYhlUtLhGFqHF+Yw==",
+            "version": "3.33.0",
+            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.33.0.tgz",
+            "integrity": "sha512-D4V/tGC2sjsoNhoMybKyGoE+v8A60hRawKQ1iFRA1zwuDgGZCBJ4ByOzZ5J8joBbi4Oam0qiPH+GhzmSBwbJng==",
             "license": "MIT",
             "dependencies": {
                 "@kwsites/file-exists": "^1.1.1",
                 "@kwsites/promise-deferred": "^1.1.1",
-                "debug": "^4.3.4"
+                "debug": "^4.4.0"
             },
             "funding": {
                 "type": "github",
@@ -3665,10 +3606,40 @@
                 "node": ">=8"
             }
         },
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -3688,22 +3659,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/strtok3": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
-            "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
-            "dependencies": {
-                "@tokenizer/token": "^0.3.0",
-                "peek-readable": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Borewit"
             }
         },
         "node_modules/supports-color": {
@@ -3821,29 +3776,13 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "is-number": "^7.0.0"
             },
             "engines": {
                 "node": ">=8.0"
-            }
-        },
-        "node_modules/token-types": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
-            "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
-            "dependencies": {
-                "@tokenizer/token": "^0.3.0",
-                "ieee754": "^1.2.1"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Borewit"
             }
         },
         "node_modules/tough-cookie": {
@@ -3987,12 +3926,6 @@
                 "node": ">=0.8.0"
             }
         },
-        "node_modules/whatwg-fetch": {
-            "version": "3.6.20",
-            "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
-            "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
-            "license": "MIT"
-        },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -4003,10 +3936,26 @@
                 "webidl-conversions": "^3.0.0"
             }
         },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/workerpool": {
-            "version": "6.5.1",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
-            "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+            "version": "9.3.4",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+            "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
             "dev": true,
             "license": "Apache-2.0"
         },
@@ -4023,6 +3972,61 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/wrap-ansi/node_modules/ansi-styles": {
             "version": "4.3.0",
@@ -4115,15 +4119,6 @@
                 "node": ">=6.0"
             }
         },
-        "node_modules/xpath": {
-            "version": "0.0.34",
-            "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.34.tgz",
-            "integrity": "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.6.0"
-            }
-        },
         "node_modules/y18n": {
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -4141,32 +4136,32 @@
             "license": "ISC"
         },
         "node_modules/yargs": {
-            "version": "16.2.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "cliui": "^7.0.2",
+                "cliui": "^8.0.1",
                 "escalade": "^3.1.1",
                 "get-caller-file": "^2.0.5",
                 "require-directory": "^2.1.1",
-                "string-width": "^4.2.0",
+                "string-width": "^4.2.3",
                 "y18n": "^5.0.5",
-                "yargs-parser": "^20.2.2"
+                "yargs-parser": "^21.1.1"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=12"
             }
         },
         "node_modules/yargs-parser": {
-            "version": "20.2.9",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
             "dev": true,
             "license": "ISC",
             "engines": {
-                "node": ">=10"
+                "node": ">=12"
             }
         },
         "node_modules/yargs-unparser": {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
     "dependencies": {
         "async": "3.2.5",
         "command-exists": "^1.2.9",
-        "diff2html": "2.5.0",
         "fast-json-stable-stringify": "2.1.0",
-        "file-type": "^16.5.4",
-        "filterxml": "2.0.0",
         "fs-extra": "8.0.1",
         "git-diff": "2.0.6",
         "global-modules-path": "3.0.0",
@@ -28,7 +25,7 @@
         "sass": "^1.77.0",
         "semver": "6.3.1",
         "shelljs": "^0.8.5",
-        "simple-git": "3.22.0",
+        "simple-git": "^3.33.0",
         "unidecode": "0.1.8",
         "xml2js": "0.6.2",
         "xmlbuilder": "13.0.2"
@@ -36,7 +33,16 @@
     "description": "Enable Continuous Integration for Vlocity",
     "devDependencies": {
         "chai": "^4.1.2",
-        "mocha": "^10.8.2"
+        "mocha": "^11"
+    },
+    "overrides": {
+        "mocha": {
+            "serialize-javascript": "^7.0.5",
+            "diff": "^8.0.3"
+        },
+        "git-diff": {
+            "diff": "^3.5.1"
+        }
     },
     "engines": {
         "node": ">=18.8.2"


### PR DESCRIPTION
Changes included: 

- Bump simple-git from 3.22.0 to ^3.33.0 
- Remove unused dependencies: diff2html, file-type, filterxml
- Replace filterxml usage with xml2js in removeInvalidXMLNodes()
- Remove dead file-type require from datapacksutils.js
- Upgrade mocha from ^10.8.2 to ^11
- Add npm overrides for serialize-javascript and diff via mocha
- Transitive fixes via npm audit fix: lodash, minimatch, picomatch, immutable, brace-expansion