### PR TITLE
fix: handle SF CLI 2.136.8 access token redaction

### DIFF
--- a/lib/sfdx.js
+++ b/lib/sfdx.js
@@ -37,7 +37,23 @@ const _mdapiDeploy = async (targetusername, deploydir, useSfdxCli, wait = 33) =>
 }
 
 const _orgDisplay = async (targetusername) => {
-	return _run(`sf org display --target-org "${targetusername}"  --verbose`);
+	var orgInfo = _run(`sf org display --target-org "${targetusername}"  --verbose`);
+
+	// SF CLI >= 2.136.8 redacts accessToken from sf org display output.
+	// Use the new dedicated command to retrieve the actual access token.
+	// Note: 'sf org auth show-access-token' only exists in SF CLI >= 2.136.8,
+	// but this block only triggers when the token is redacted (i.e., on >= 2.136.8).
+	if (!orgInfo.accessToken || orgInfo.accessToken.includes('[REDACTED]')) {
+		try {
+			var authResult = _run(`sf org auth show-access-token --target-org "${targetusername}" --no-prompt`);
+			orgInfo.accessToken = authResult.accessToken;
+		} catch (e) {
+			VlocityUtils.error('Failed to retrieve access token via "sf org auth show-access-token". Please upgrade SF CLI to >= 2.136.8 or re-authenticate.', e.message || e);
+			throw new Error('Unable to retrieve access token. Ensure SF CLI >= 2.136.8 is installed and run "sf org login web" to re-authenticate.');
+		}
+	}
+
+	return orgInfo;
 }
 
 const _sourceDeploy = async (targetusername,sourcePath) =>{


### PR DESCRIPTION
## Summary

- **Fixes #789** (`TypeError: Only absolute URLs are supported`)
- **Fixes #790** (`Vlocity authentication fails with @salesforce/cli >= 2.136.8`)

Starting May 27, 2026, `@salesforce/cli@2.136.8` redacts `accessToken` from `sf org display --json` output ([SF CLI announcement](https://github.com/forcedotcom/cli/issues/3560)). This breaks VBT's `sfdxLogin()` flow, causing `INVALID_AUTH_HEADER` errors on all API calls.

### Root Cause
- `sf org display --json` now returns `"accessToken": "[REDACTED]..."` 
- VBT passes this redacted string to `jsforce.Connection`, which fails on every API call
- jsforce then resets `instanceUrl` to `''` after auth failure, causing the secondary `TypeError: Only absolute URLs are supported` error (#789)

### Fix
When a redacted/missing token is detected in the `sf org display` response, fall back to the new dedicated command `sf org auth show-access-token --target-org <username> --no-prompt` to retrieve the actual access token.

### Backward Compatibility
The fix only triggers when the token is missing or contains `[REDACTED]`. Older SF CLI versions (< 2.136.8) that still include the token in `sf org display` output are completely unaffected — the fallback code is never executed.

## Test plan

- [x] Tested with SF CLI **2.135.7** (old) — 130 OmniScripts exported successfully ✅
- [x] Tested with SF CLI **2.136.8** (new, without fix) — `INVALID_AUTH_HEADER` ❌
- [x] Tested with SF CLI **2.136.8** (new, with fix) — 130 OmniScripts exported successfully ✅
- [x] Verified `sf org auth show-access-token` command does NOT exist in older CLI versions but is never called (guard condition prevents it)

## References
- SF CLI announcement: https://github.com/forcedotcom/cli/issues/3560
- Production cutover date: May 27, 2026
- `SF_TEMP_SHOW_SECRETS=true` workaround will be removed in summer 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)