### PR TITLE
Upgrade puppeteer-core from v6 to v24

### DIFF
--- a/lib/datapacktypes/flexcard.js
+++ b/lib/datapacktypes/flexcard.js
@@ -116,7 +116,7 @@ FlexCard.prototype.monitorFlexCardCompilation = async function(page, jobInfo, co
             errorMessage = ' Error: ' + e;
         }
         tries++;
-        await page.waitForTimeout(jobInfo.defaultLWCPullTimeInSeconds * 1000);
+        await new Promise(resolve => setTimeout(resolve, jobInfo.defaultLWCPullTimeInSeconds * 1000));
     }
 
     if (tries == maxNumOfTries) {
@@ -182,7 +182,7 @@ FlexCard.prototype.compileBulkFlexCards = async function(jobInfo, idsArray, page
     VlocityUtils.verbose('LWC FlexCards Activation URL', flexCardCompilePage);
 
     await page.goto(flexCardCompilePage, {timeout: loginTimeout});
-    await page.waitForTimeout(5000);
+    await new Promise(resolve => setTimeout(resolve, 5000));
 
     // Use common monitoring method
     const context = {
@@ -211,7 +211,7 @@ FlexCard.prototype.compileFlexCardLwcIndividual = async function(jobInfo, flexCa
         VlocityUtils.verbose('LWC FlexCard Activation URL', flexCardCompilePage);
 
         await page.goto(flexCardCompilePage, {timeout: loginTimeout});
-        await page.waitForTimeout(5000);
+        await new Promise(resolve => setTimeout(resolve, 5000));
 
         // Use common monitoring method
         const context = {

--- a/lib/datapacktypes/omniscript.js
+++ b/lib/datapacktypes/omniscript.js
@@ -345,7 +345,7 @@ OmniScript.prototype.compileOSLWC = async function (jobInfo, omniScriptId, omniS
                     VlocityUtils.verbose('LWC Activation URL', omniScriptDisignerpageLink);
     
                     await page.goto(omniScriptDisignerpageLink);
-                    await page.waitForTimeout(5000);
+                    await new Promise(resolve => setTimeout(resolve, 5000));
     
                     let tries = 0;
                     var errorMessage;
@@ -388,7 +388,7 @@ OmniScript.prototype.compileOSLWC = async function (jobInfo, omniScriptId, omniS
                             errorMessage = ' Error: ' + e;
                         }
                         tries++;
-                        await page.waitForTimeout(jobInfo.defaultLWCPullTimeInSeconds * 1000);
+                        await new Promise(resolve => setTimeout(resolve, jobInfo.defaultLWCPullTimeInSeconds * 1000));
                     }
     
                     if (tries == maxNumOfTries) {

--- a/lib/datapacktypes/vlocitycard.js
+++ b/lib/datapacktypes/vlocitycard.js
@@ -64,7 +64,7 @@ VlocityCard.prototype.flexCardDeployWithPuppeteer = async function(jobInfo){
             
             await page.goto(flexCardCompilePage, {timeout: loginTimeout});
 
-            await page.waitForTimeout(5000);
+            await new Promise(resolve => setTimeout(resolve, 5000));
             
             let tries = 0;
             let jsonError;
@@ -99,7 +99,7 @@ VlocityCard.prototype.flexCardDeployWithPuppeteer = async function(jobInfo){
                     VlocityUtils.error('Error Activating LWC',e);
                 }
                 tries++;
-                await page.waitForTimeout(jobInfo.defaultLWCPullTimeInSeconds*1000);
+                await new Promise(resolve => setTimeout(resolve, jobInfo.defaultLWCPullTimeInSeconds*1000));
             }
 
             if (tries == maxNumOfTries) {

--- a/lib/datapacktypes/vlocityuilayout.js
+++ b/lib/datapacktypes/vlocityuilayout.js
@@ -74,8 +74,8 @@ VlocityUILayout.prototype.onDeployFinish = async function(jobInfo) {
                     
                     await page.goto(pageCarddesignernew, {timeout: loginTimeout});
 
-                    await page.waitForTimeout(5000);
-                    
+                    await new Promise(resolve => setTimeout(resolve, 5000));
+
                     let tries = 0;
                     var errorMessage;
                     var maxNumOfTries = Math.ceil((60/jobInfo.defaultLWCPullTimeInSeconds)*jobInfo.defaultMinToWaitForLWCClassicCards);
@@ -111,7 +111,7 @@ VlocityUILayout.prototype.onDeployFinish = async function(jobInfo) {
                             errorMessage = ' Error: ' + e;
                         }
                         tries++;
-                        await page.waitForTimeout(jobInfo.defaultLWCPullTimeInSeconds*1000);
+                        await new Promise(resolve => setTimeout(resolve, jobInfo.defaultLWCPullTimeInSeconds*1000));
                     }
 
                     if (tries == maxNumOfTries) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
                 "properties": "1.2.1",
                 "psl": "1.9.0",
                 "punycode": "2.3.1",
-                "puppeteer-core": "^6.0.0",
+                "puppeteer-core": "^24.43.0",
                 "runtime-plugin-manager-clone": "0.1.0",
                 "sass": "^1.77.0",
                 "semver": "6.3.1",
@@ -515,6 +515,39 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@puppeteer/browsers": {
+            "version": "2.13.2",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
+            "integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "extract-zip": "^2.0.1",
+                "progress": "^2.0.3",
+                "proxy-agent": "^6.5.0",
+                "semver": "^7.7.4",
+                "tar-fs": "^3.1.1",
+                "yargs": "^17.7.2"
+            },
+            "bin": {
+                "browsers": "lib/cjs/main-cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@puppeteer/browsers/node_modules/semver": {
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/@sindresorhus/is": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -531,6 +564,12 @@
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.6.tgz",
             "integrity": "sha512-vL9EVn/v+OhZ+Wcs6O4iKE9EUpwHUqHmCtNUMWjqp+6dr85+XPOSGTEsqYNq1Vn04uk9SWlOVmx9J48ggJVT2Q==",
+            "license": "MIT"
+        },
+        "node_modules/@tootallnate/quickjs-emscripten": {
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+            "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
             "license": "MIT"
         },
         "node_modules/@types/debug": {
@@ -702,6 +741,18 @@
                 "node": "*"
             }
         },
+        "node_modules/ast-types": {
+            "version": "0.13.4",
+            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+            "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/async": {
             "version": "3.2.5",
             "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
@@ -732,11 +783,116 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "license": "MIT"
         },
+        "node_modules/b4a": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+            "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "react-native-b4a": "*"
+            },
+            "peerDependenciesMeta": {
+                "react-native-b4a": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "license": "MIT"
+        },
+        "node_modules/bare-events": {
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
+            "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "bare-abort-controller": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-abort-controller": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/bare-fs": {
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+            "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bare-events": "^2.5.4",
+                "bare-path": "^3.0.0",
+                "bare-stream": "^2.6.4",
+                "bare-url": "^2.2.2",
+                "fast-fifo": "^1.3.2"
+            },
+            "engines": {
+                "bare": ">=1.16.0"
+            },
+            "peerDependencies": {
+                "bare-buffer": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-buffer": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/bare-os": {
+            "version": "3.9.1",
+            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+            "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "bare": ">=1.14.0"
+            }
+        },
+        "node_modules/bare-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+            "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bare-os": "^3.0.1"
+            }
+        },
+        "node_modules/bare-stream": {
+            "version": "2.13.1",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+            "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "streamx": "^2.25.0",
+                "teex": "^1.0.1"
+            },
+            "peerDependencies": {
+                "bare-abort-controller": "*",
+                "bare-buffer": "*",
+                "bare-events": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-abort-controller": {
+                    "optional": true
+                },
+                "bare-buffer": {
+                    "optional": true
+                },
+                "bare-events": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/bare-url": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+            "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bare-path": "^3.0.0"
+            }
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
@@ -765,6 +921,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/basic-ftp": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+            "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/bl": {
@@ -943,6 +1108,19 @@
                 "node": ">=10"
             }
         },
+        "node_modules/chromium-bidi": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+            "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "mitt": "^3.0.1",
+                "zod": "^3.24.1"
+            },
+            "peerDependencies": {
+                "devtools-protocol": "*"
+            }
+        },
         "node_modules/cli-cursor": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -980,7 +1158,6 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
             "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "string-width": "^4.2.0",
@@ -995,7 +1172,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
@@ -1011,7 +1187,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
@@ -1024,14 +1199,12 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/cliui/node_modules/wrap-ansi": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",
@@ -1154,6 +1327,15 @@
             "integrity": "sha512-YW32lKOmIBgbxtu3g5SaiqWNwa/9ISQt2EcgOq0+RAIFufFp9is6tqNnKahqE5kuKvrnYAzs28r+s6pXJR8Vcw==",
             "license": "MIT"
         },
+        "node_modules/data-uri-to-buffer": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+            "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/debug": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1209,6 +1391,20 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/degenerator": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+            "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ast-types": "^0.13.4",
+                "escodegen": "^2.1.0",
+                "esprima": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1232,9 +1428,9 @@
             }
         },
         "node_modules/devtools-protocol": {
-            "version": "0.0.842839",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.842839.tgz",
-            "integrity": "sha512-iI3v9uuGUW02vPUXTvxl4ijnCPL/RGRVR9I+U8s7+9OG9An/bvExjQ0KrXE9V0QBLra7wANhZctB00FKBSn1gw==",
+            "version": "0.0.1608973",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+            "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
             "license": "BSD-3-Clause"
         },
         "node_modules/dunder-proto": {
@@ -1322,7 +1518,6 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
             "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -1337,6 +1532,27 @@
                 "node": ">=0.8.0"
             }
         },
+        "node_modules/escodegen": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "esprima": "^4.0.1",
+                "estraverse": "^5.2.0",
+                "esutils": "^2.0.2"
+            },
+            "bin": {
+                "escodegen": "bin/escodegen.js",
+                "esgenerate": "bin/esgenerate.js"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "optionalDependencies": {
+                "source-map": "~0.6.1"
+            }
+        },
         "node_modules/esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -1348,6 +1564,33 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/estraverse": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/esutils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/events-universal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+            "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bare-events": "^2.7.0"
             }
         },
         "node_modules/extract-zip": {
@@ -1369,6 +1612,12 @@
             "optionalDependencies": {
                 "@types/yauzl": "^2.9.1"
             }
+        },
+        "node_modules/fast-fifo": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+            "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+            "license": "MIT"
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
@@ -1515,12 +1764,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "license": "MIT"
-        },
         "node_modules/fs-extra": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.0.1.tgz",
@@ -1587,7 +1830,6 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
@@ -1656,6 +1898,20 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/get-uri": {
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+            "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+            "license": "MIT",
+            "dependencies": {
+                "basic-ftp": "^5.0.2",
+                "data-uri-to-buffer": "^6.0.2",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/git-diff": {
@@ -1802,6 +2058,28 @@
             "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
             "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
             "license": "MIT"
+        },
+        "node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/http-proxy-agent/node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
         },
         "node_modules/https-proxy-agent": {
             "version": "5.0.1",
@@ -1987,6 +2265,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
+            }
+        },
+        "node_modules/ip-address": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
             }
         },
         "node_modules/is-core-module": {
@@ -2507,10 +2794,10 @@
                 "node": ">=8"
             }
         },
-        "node_modules/mkdirp-classic": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+        "node_modules/mitt": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+            "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
             "license": "MIT"
         },
         "node_modules/mocha": {
@@ -2652,6 +2939,15 @@
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
             "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
             "license": "ISC"
+        },
+        "node_modules/netmask": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+            "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4.0"
+            }
         },
         "node_modules/node-addon-api": {
             "version": "7.1.1",
@@ -2909,13 +3205,58 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/p-try": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+        "node_modules/pac-proxy-agent": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+            "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+            "license": "MIT",
+            "dependencies": {
+                "@tootallnate/quickjs-emscripten": "^0.23.0",
+                "agent-base": "^7.1.2",
+                "debug": "^4.3.4",
+                "get-uri": "^6.0.1",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.6",
+                "pac-resolver": "^7.0.1",
+                "socks-proxy-agent": "^8.0.5"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/pac-proxy-agent/node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
             "license": "MIT",
             "engines": {
-                "node": ">=6"
+                "node": ">= 14"
+            }
+        },
+        "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/pac-resolver": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+            "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+            "license": "MIT",
+            "dependencies": {
+                "degenerator": "^5.0.0",
+                "netmask": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/package-json-from-dist": {
@@ -2929,6 +3270,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -3012,70 +3354,6 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
-        "node_modules/pkg-dir": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-            "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-            "license": "MIT",
-            "dependencies": {
-                "find-up": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/pkg-dir/node_modules/find-up": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-            "license": "MIT",
-            "dependencies": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/pkg-dir/node_modules/locate-path": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-            "license": "MIT",
-            "dependencies": {
-                "p-locate": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/pkg-dir/node_modules/p-limit": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-            "license": "MIT",
-            "dependencies": {
-                "p-try": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/pkg-dir/node_modules/p-locate": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-            "license": "MIT",
-            "dependencies": {
-                "p-limit": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/progress": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -3094,6 +3372,56 @@
                 "node": ">=0.10"
             }
         },
+        "node_modules/proxy-agent": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+            "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "^4.3.4",
+                "http-proxy-agent": "^7.0.1",
+                "https-proxy-agent": "^7.0.6",
+                "lru-cache": "^7.14.1",
+                "pac-proxy-agent": "^7.1.0",
+                "proxy-from-env": "^1.1.0",
+                "socks-proxy-agent": "^8.0.5"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/proxy-agent/node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/proxy-agent/node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/proxy-agent/node_modules/lru-cache": {
+            "version": "7.18.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -3107,9 +3435,9 @@
             "license": "MIT"
         },
         "node_modules/pump": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-            "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
             "license": "MIT",
             "dependencies": {
                 "end-of-stream": "^1.1.0",
@@ -3126,26 +3454,21 @@
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-6.0.0.tgz",
-            "integrity": "sha512-Mm4lVSM8CJUrHSLt2zHjlW9B2D5B3JRbkbmxzGaGTauaB9gTrM+r7gk88xfRWuaBy81pRG+nTtCBdMPzO7pjqg==",
+            "version": "24.43.1",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
+            "integrity": "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "debug": "^4.1.0",
-                "devtools-protocol": "0.0.842839",
-                "extract-zip": "^2.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "node-fetch": "^2.6.1",
-                "pkg-dir": "^4.2.0",
-                "progress": "^2.0.1",
-                "proxy-from-env": "^1.0.0",
-                "rimraf": "^3.0.2",
-                "tar-fs": "^2.0.0",
-                "unbzip2-stream": "^1.3.3",
-                "ws": "^7.2.3"
+                "@puppeteer/browsers": "2.13.2",
+                "chromium-bidi": "14.0.0",
+                "debug": "^4.4.3",
+                "devtools-protocol": "0.0.1608973",
+                "typed-query-selector": "^2.12.2",
+                "webdriver-bidi-protocol": "0.4.1",
+                "ws": "^8.20.0"
             },
             "engines": {
-                "node": ">=10.18.1"
+                "node": ">=18"
             }
         },
         "node_modules/readable-stream": {
@@ -3190,7 +3513,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -3227,65 +3549,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "deprecated": "Rimraf versions prior to v4 are no longer supported",
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/rimraf/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/rimraf/node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/rimraf/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/run-async": {
@@ -3568,6 +3831,63 @@
                 "url": "https://github.com/steveukx/git-js?sponsor=1"
             }
         },
+        "node_modules/smart-buffer": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/socks": {
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+            "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+            "license": "MIT",
+            "dependencies": {
+                "ip-address": "^10.1.1",
+                "smart-buffer": "^4.2.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/socks-proxy-agent": {
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+            "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "^4.3.4",
+                "socks": "^2.8.3"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/socks-proxy-agent/node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "license": "BSD-3-Clause",
+            "optional": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/source-map-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3582,6 +3902,17 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
             "license": "BSD-3-Clause"
+        },
+        "node_modules/streamx": {
+            "version": "2.26.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.26.0.tgz",
+            "integrity": "sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A==",
+            "license": "MIT",
+            "dependencies": {
+                "events-universal": "^1.0.0",
+                "fast-fifo": "^1.3.2",
+                "text-decoder": "^1.1.0"
+            }
         },
         "node_modules/string_decoder": {
             "version": "1.3.0",
@@ -3703,37 +4034,29 @@
             }
         },
         "node_modules/tar-fs": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-            "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+            "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
             "license": "MIT",
             "dependencies": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
                 "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
+                "tar-stream": "^3.1.5"
+            },
+            "optionalDependencies": {
+                "bare-fs": "^4.0.1",
+                "bare-path": "^3.0.0"
             }
         },
-        "node_modules/tar-fs/node_modules/chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "license": "ISC"
-        },
         "node_modules/tar-stream": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+            "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
             "license": "MIT",
             "dependencies": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-            },
-            "engines": {
-                "node": ">=6"
+                "b4a": "^1.6.4",
+                "bare-fs": "^4.5.5",
+                "fast-fifo": "^1.2.0",
+                "streamx": "^2.15.0"
             }
         },
         "node_modules/tar/node_modules/mkdirp": {
@@ -3746,6 +4069,24 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/teex": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+            "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+            "license": "MIT",
+            "dependencies": {
+                "streamx": "^2.12.5"
+            }
+        },
+        "node_modules/text-decoder": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+            "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "b4a": "^1.6.4"
             }
         },
         "node_modules/through": {
@@ -3843,15 +4184,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/unbzip2-stream": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-            "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-            "license": "MIT",
-            "dependencies": {
-                "buffer": "^5.2.1",
-                "through": "^2.3.8"
-            }
+        "node_modules/typed-query-selector": {
+            "version": "2.12.2",
+            "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+            "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+            "license": "MIT"
         },
         "node_modules/undici-types": {
             "version": "7.13.0",
@@ -3896,6 +4233,12 @@
             "dependencies": {
                 "defaults": "^1.0.3"
             }
+        },
+        "node_modules/webdriver-bidi-protocol": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+            "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+            "license": "Apache-2.0"
         },
         "node_modules/webidl-conversions": {
             "version": "3.0.1",
@@ -4068,16 +4411,16 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "7.5.10",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "license": "MIT",
             "engines": {
-                "node": ">=8.3.0"
+                "node": ">=10.0.0"
             },
             "peerDependencies": {
                 "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
+                "utf-8-validate": ">=5.0.2"
             },
             "peerDependenciesMeta": {
                 "bufferutil": {
@@ -4123,7 +4466,6 @@
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=10"
@@ -4139,7 +4481,6 @@
             "version": "17.7.2",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
             "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cliui": "^8.0.1",
@@ -4158,7 +4499,6 @@
             "version": "21.1.1",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
             "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=12"
@@ -4201,6 +4541,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "properties": "1.2.1",
         "psl": "1.9.0",
         "punycode": "2.3.1",
-        "puppeteer-core": "^6.0.0",
+        "puppeteer-core": "^24.43.0",
         "runtime-plugin-manager-clone": "0.1.0",
         "sass": "^1.77.0",
         "semver": "6.3.1",


### PR DESCRIPTION
Bumps `puppeteer-core` from `^6.0.0` (Sep 2020) to `^24.43.0`, an 18-major-version jump, and replaces the 9 call sites that use `page.waitForTimeout()` (removed in Puppeteer v22.0.0).

### Why v24 specifically, not the latest v25

`puppeteer-core@25.x` requires Node `>=22.12.0` (v25 dropped Node 18 - see [puppeteer/puppeteer#14342](https://github.com/puppeteer/puppeteer/issues/14342)). This project's `package.json` declares `engines.node: ">=18.8.2"`, so jumping to v25 would silently raise that floor and drop Node 18/20 users of the published `vlocity` CLI. `puppeteer-core@24.43.x` is the newest release line that still declares `engines.node: ">=18"`, keeping the existing Node support contract intact.

### Required code changes

`page.waitForTimeout()` was removed in Puppeteer v22.0.0. The 9 call sites across the four DataPack-type modules are rewritten to the same `setTimeout`-based idiom that's already used elsewhere in these files for `msToWaitForLWCDeploy`.

No other Puppeteer API changes were required - `puppeteer.launch`, `browser.newPage`, `page.goto`, `page.waitForNavigation`, `page.waitForSelector`, `page.evaluate`, `browser.close`, and the `headless` / `executablePath` / `args` launch options used here are all still supported in v24.

### Behavioural changes from the upgrade

Two pre-existing things worth being aware of when reviewing - neither is changed by this PR, but both are touched by the upgrade in practice:

1. `headless: true` semantics changed in Puppeteer v22. It now launches Chrome's new headless mode (real Chrome) rather than the old shell. With the system-Chrome executablePath selected by `UtilityService.getPuppeteerOptions`, this should work the same, but it is a behavioural change in the underlying browser.
2. The `.local-chromium` fallback in `lib/utilityservice.js` is effectively dead code with modern Puppeteer. It scans `node_modules/puppeteer/.local-chromium` with `chrome-mac` / `chrome-linux` / `chrome-win` folder names. Since Puppeteer v15 the bundled Chromium has been managed by `@puppeteer/browsers`, which uses a different cache layout (chrome-mac-x64 / chrome-linux64 / chrome-win64) in a different directory. This path matters only for users who relied on `npm install puppeteer -g` to provide the browser - anyone using system Chrome or `puppeteerExecutablePath` is unaffected.