### PR TITLE
fix(ci): pin pkg build targets to node18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN npm install --global publish-release
 
 RUN npm install --global pkg-fetch
 #RUN pkg-fetch -n node10 -p win -a x64
-RUN pkg-fetch -n node16 -p linux -a x64
-RUN pkg-fetch -n node16 -p macos -a x64
+RUN pkg-fetch -n node18 -p linux -a x64
+RUN pkg-fetch -n node18 -p macos -a x64
 
 RUN npm install --global pkg
 

--- a/package.json
+++ b/package.json
@@ -78,9 +78,9 @@
             "node_modules/salesforce-alm/**/*.js"
         ],
         "targets": [
-            "win-x64",
-            "macos",
-            "linux"
+            "node18-win-x64",
+            "node18-macos",
+            "node18-linux"
         ]
     },
     "preferGlobal": true,


### PR DESCRIPTION
## Summary

Fixes the CI publish step failure: `Error! No available node version satisfies 'node22'`

After upgrading CI to `node:22` (PR #794), the `pkg` binary builder (v5.8.1) fails because it doesn't support Node 22. `pkg` infers the target Node version from the host, producing an unsupported target.

### Fix
- Explicitly pin `pkg` targets to `node18` in `package.json` (the highest version `pkg` supports)
- Update `Dockerfile` prefetch from `node16` to `node18`

```json
"targets": [
    "node18-win-x64",
    "node18-macos",
    "node18-linux"
]
```

CI now **runs** on Node 22 (required for SF CLI) but **builds binaries** targeting Node 18 runtime (max supported by `pkg`). Produced binaries work fine since VBT requires Node >= 18.

## Test plan

- [ ] CloudBees publish pipeline passes with `pkg . --out-path ./dist`
- [ ] Produced binaries (`vlocity-linux`, `vlocity-macos`, `vlocity-win.exe`) execute correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)