### PR TITLE
@W-24123573@ Redact sessionId from persisted job-state files (CWE-312)

### DIFF
--- a/lib/datapacksutils.js
+++ b/lib/datapacksutils.js
@@ -2563,7 +2563,7 @@ DataPacksUtils.prototype.saveCurrentJobInfo = async function(jobInfo, force) {
         var startSaveTime = Date.now();
         VlocityUtils.verbose('Saving File Start');
 
-        var nonWriteable = [ 'sObjectsInfo', 'errorHandling' ];
+        var nonWriteable = [ 'sObjectsInfo', 'errorHandling', 'sessionId' ];
 
         var savedData = {}
 

--- a/test/datapacksutils.spec.js
+++ b/test/datapacksutils.spec.js
@@ -1,7 +1,11 @@
 'use strict'
 
+require('../lib/vlocityutils'); // defines the global VlocityUtils used by saveCurrentJobInfo
 const _datapacksutils = require('../lib/datapacksutils');
 const expect = require('chai').expect;
+const fs = require('fs-extra');
+const os = require('os');
+const path = require('path');
 
 describe('DataPacksUtils', () => 
 {
@@ -26,5 +30,30 @@ describe('DataPacksUtils', () =>
 
             generatedGuids[newGuid] = newGuid;
         }
+    });
+
+    describe('saveCurrentJobInfo', () => {
+        // W-24123573: a live Salesforce sessionId must not be persisted to currentJobInfo.json / .bak.
+        it('does not persist sessionId to disk but keeps it in memory', async () => {
+            const tempFolder = fs.mkdtempSync(path.join(os.tmpdir(), 'vbt-wi-'));
+            const infoFile = path.join(tempFolder, 'currentJobInfo.json');
+            const utils = new _datapacksutils({ tempFolder });
+
+            const SECRET = 'FAKE_SESSION_ID_do_not_persist';
+            const jobInfo = { jobAction: 'Deploy', sessionId: SECRET, instanceUrl: 'https://example.my.salesforce.com' };
+
+            await utils.saveCurrentJobInfo(jobInfo, true);
+
+            const written = fs.readFileSync(infoFile, 'utf8');
+            const bak = fs.readFileSync(infoFile + '.bak', 'utf8');
+
+            expect(written).to.not.contain('sessionId');
+            expect(written).to.not.contain(SECRET);
+            expect(bak).to.not.contain(SECRET);
+            expect(JSON.parse(written).instanceUrl).to.eq(jobInfo.instanceUrl); // non-secret data preserved
+            expect(jobInfo.sessionId).to.eq(SECRET); // restored in memory so the running job still authenticates
+
+            fs.removeSync(tempFolder);
+        });
     });
 })


### PR DESCRIPTION
## Summary
- Add `sessionId` to the strip-and-restore list in `saveCurrentJobInfo` (`lib/datapacksutils.js`), so a live Salesforce `sessionId` is no longer serialized to `vlocity-temp/currentJobInfo.json` or its `.bak` copy.
- The field is removed just before the file is written and restored to the in-memory job object immediately after, so an in-progress job keeps the `sessionId` it needs to authenticate.
- Add a mocha/chai regression test in `test/datapacksutils.spec.js` asserting `sessionId` is absent on disk but retained in memory (and non-secret data such as `instanceUrl` is preserved).

## Why this is needed
`saveCurrentJobInfo` serialized the entire `jobInfo` object while stripping only `sObjectsInfo` and `errorHandling`. The `password`/`accessToken` redaction happens elsewhere (`lib/vlocity.js`), but `sessionId` was never removed — so a live Salesforce session token (sourced from `sf.sessionId` in `lib/vlocitycli.js`) was written in cleartext to the job-state files. This is CWE-312 (Cleartext Storage of Sensitive Information), tracked in W-24123573. Anyone with local read access to the working directory — or a CI job that archives `vlocity-temp/` as a build artifact — could read and reuse the session while it is valid. `.gitignore` already excludes `vlocity-temp/`, so the git-commit exposure vector is closed; this addresses the remaining local/CI-artifact vectors.

## How this was tested
Verified at three levels — a unit test with a fake token, then a real deploy+activate against a sandbox with a **live** `sessionId`, plus a control run with the fix reverted.

**1. Regression test (unit) — `test/datapacksutils.spec.js`**
Constructs `DataPacksUtils` in a temp folder, calls `saveCurrentJobInfo` with a job object carrying a fake `sessionId`, then asserts:
- the written `currentJobInfo.json` and its `.bak` contain neither the `sessionId` key nor the secret value;
- non-secret data (`instanceUrl`) is still persisted;
- the in-memory `jobInfo.sessionId` is restored after the write (so the running job can still authenticate).

Result: **passes with the fix, fails without it** (without the fix the secret is found on disk).

**2. Real deploy+activate WITH the fix (live token)**
Deployed and activated 5 OmniScripts on a sandbox authenticating with a real `-sf.sessionId`. All 5 activated at their new versions, and the `currentJobInfo.json`/`.bak` written to `vlocity-temp/` during the run contained **no `sessionId` key and no session-token value**. Success was confirmed not by the VBT CLI summary line (which is unreliable) but by object state: newest `OmniProcess` version `IsActive=true` with a matching `OmniProcessCompilation` row, and the async activation jobs `Completed` with `ExtendedStatus = null`.

**3. Control run WITHOUT the fix (fix reverted)**
Same deploy on the same org with the fix reverted. Deploy+activate also succeeded, but the written job-state files **did contain the live `sessionId`** in cleartext — confirming the fix is what removes it and that the test is non-vacuous (the field is genuinely present on disk when unpatched).

## Compatibility
No API or behavior change. The `sessionId` remains available to the running job in memory (it is captured by the `Vlocity` constructor before serialization), so authentication is unaffected; only the on-disk job-state file changes. Verified end-to-end with a real deploy + activate of 5 OmniScripts on a sandbox using `-sf.sessionId` auth: all 5 activated successfully at their new versions, and the written `currentJobInfo.json`/`.bak` contained no `sessionId` key and no session-token value.
