### PR TITLE
@W-24123570: stop logging live session token via frontdoor URL

### DIFF
--- a/lib/datapacktypes/omniscript.js
+++ b/lib/datapacktypes/omniscript.js
@@ -315,7 +315,6 @@ OmniScript.prototype.compileOSLWC = async function (jobInfo, omniScriptId, omniS
                     var siteUrl = this.vlocity.jsForceConnection.instanceUrl;
                     var sessionToken = this.vlocity.jsForceConnection.accessToken;
                     var loginURl = siteUrl + '/secur/frontdoor.jsp?sid=' + sessionToken;
-                    VlocityUtils.verbose('LWC Activation Login URL', loginURl);
                     var browser;
     
                     try {


### PR DESCRIPTION
VlocityUtils.verbose('LWC Activation Login URL', loginURl) logged the full /secur/frontdoor.jsp?sid=<accessToken> URL, including the live jsForce session token, whenever --verbose is enabled. That message ends up in VlocityUtils.fullLog, which is written to VlocityBuildLog.yaml and a copy under <tempFolder>/logs/ - a persisted plaintext file, not just console output. Anyone able to read that file/CI artifact could reuse the token via frontdoor.jsp to hijack the runner's authenticated session (CWE-532/598).

loginURl is only needed for page.goto() right after, matching the sibling LWC-activation call sites in flexcard.js/vlocitycard.js/ vlocityuilayout.js, which build the same frontdoor URL but never log it.