### PR TITLE
@W-24123540@ Prevent path traversal / arbitrary file write in expandSFDX (CWE-22)

### DIFF
--- a/lib/datapacksexpand.js
+++ b/lib/datapacksexpand.js
@@ -63,6 +63,16 @@ DataPacksExpand.prototype.sanitizeDataPackKey = function(key) {
     return this.generateFolderOrFilename(key);
 };
 
+// Guard against path traversal (CWE-22): reject any target that resolves outside baseDir.
+DataPacksExpand.prototype.assertPathWithin = function(baseDir, targetPath) {
+    var resolvedBase = path.resolve(baseDir);
+    var resolvedTarget = path.resolve(targetPath);
+    if (resolvedTarget !== resolvedBase && !resolvedTarget.startsWith(resolvedBase + path.sep)) {
+        throw new Error('Path traversal detected: refusing to write outside SFDX project directory: ' + targetPath);
+    }
+    return resolvedTarget;
+};
+
 //Generate the full file path
 DataPacksExpand.prototype.generateFilepath = function(dataPackType, parentName, filename, extension) {
     var validFileName = this.generateFolderOrFilename(filename, extension);
@@ -1463,6 +1473,8 @@ DataPacksExpand.prototype.expandSFDX = async function(dataPack, jobInfo) {
 
         var fullFilePath = path.join(jobInfo.sfdxFolderPath, 'main', 'default', dataPack.VlocityDataPackKey).replace(/%vlocity_namespace%/g, namespace);
 
+        this.assertPathWithin(jobInfo.sfdxFolderPath, fullFilePath);
+
         if (namespace != '%vlocity_namespace%') {
             dataPack.SFDXData = dataPack.SFDXData.replace(/%vlocity_namespace%/g, namespace);
         }
@@ -1474,7 +1486,9 @@ DataPacksExpand.prototype.expandSFDX = async function(dataPack, jobInfo) {
 
             for (resourceFile of allFiles) {
                 if (resourceFile.originalFilePath) {
-                    fs.copySync(resourceFile.originalFilePath, path.join(jobInfo.sfdxFolderPath, resourceFile.filePath));
+                    var resourceDestPath = path.join(jobInfo.sfdxFolderPath, resourceFile.filePath);
+                    this.assertPathWithin(jobInfo.sfdxFolderPath, resourceDestPath);
+                    fs.copySync(resourceFile.originalFilePath, resourceDestPath);
                 }
             }
         } else {

--- a/test/datapacksexpand.spec.js
+++ b/test/datapacksexpand.spec.js
@@ -58,7 +58,32 @@ describe('DataPacksExpand', async () =>
     })   
   })
 
-  describe('getNameWithFields', () => { 
+  describe('assertPathWithin (path-traversal guard)', () => {
+    const path = require('path');
+    var base = path.resolve('/tmp/sfdx-project/force-app');
+
+    it('should be a function', () => {
+      expect(datapacksexpand.assertPathWithin).to.be.a('function')
+    })
+    it('should return the resolved path for a target inside the base', () => {
+      var target = path.join(base, 'main', 'default', 'OmniScript', 'Type_SubType_English.json');
+      expect(datapacksexpand.assertPathWithin(base, target)).to.be.eq(path.resolve(target));
+    })
+    it('should allow legitimate DataPack keys containing / separators', () => {
+      var target = path.join(base, 'main', 'default', 'DataRaptor/MyDR/MyDR.json');
+      expect(() => datapacksexpand.assertPathWithin(base, target)).to.not.throw();
+    })
+    it('should throw on a ../ traversal that escapes the base', () => {
+      var target = path.join(base, 'main', 'default', '../../../../../../etc/cron.d/evil');
+      expect(() => datapacksexpand.assertPathWithin(base, target)).to.throw(/traversal/i);
+    })
+    it('should throw on a sibling-directory prefix escape', () => {
+      var target = base + '-evil/payload';
+      expect(() => datapacksexpand.assertPathWithin(base, target)).to.throw(/traversal/i);
+    })
+  })
+
+  describe('getNameWithFields', () => {
     it('should be a function', () => {
       expect(datapacksexpand.getNameWithFields).to.be.a('function')
     })


### PR DESCRIPTION
### W-24123540 — Path Traversal to Arbitrary File Write in `expandSFDX` (CWE-22, P2)

**Source:** PSA Security Bugs / AgenticSAST chain `b0c91bf83c432d757d64ece1c201504b`

#### The bug
In `lib/datapacksexpand.js`, `expandSFDX` joined the DataPack-controlled `VlocityDataPackKey`
(and `resourceFile.filePath`) into an output path under `jobInfo.sfdxFolderPath` and wrote
attacker-supplied content with no `..`/containment sanitization. Because `path.join` resolves
`../` segments upward, a traversal key escaped the intended SFDX project directory, giving
**arbitrary file write on the build/CI host** from an attacker-authored (compromised export /
shared Vlocity package) DataPack.

Two write sinks were affected:
- `:1481` `fs.outputFile(fullFilePath, dataPack.SFDXData, ...)`
- `:1477` `fs.copySync(..., path.join(jobInfo.sfdxFolderPath, resourceFile.filePath))` (staticresources)

#### The fix
Add `DataPacksExpand.prototype.assertPathWithin(baseDir, targetPath)` — resolves both paths and
throws unless the target stays within the resolved base (`=== base` or `startsWith(base + path.sep)`,
which correctly rejects sibling-prefix escapes like `force-app-evil`). Both write sinks now route
through it before touching the filesystem. This matches the remediation prescribed on the ticket
("resolve the path and reject any result outside `jobInfo.sfdxFolderPath`").

Legitimate DataPack keys that contain `/` separators (e.g. `OmniScript/MACD_Move_English`,
`DataRaptor/Name`) still resolve under the base and are unaffected.

#### Failure semantics
`assertPathWithin` throws (fail-closed). `expandSFDX` already lets `fs.outputFile`, `fs.copySync`,
and `JSON.parse` propagate errors the same way — no local `try/catch` — so the guard is consistent
with the function's existing error model rather than introducing a new one.

#### Tests
Added 5 unit specs in `test/datapacksexpand.spec.js` (`assertPathWithin` block): inside-base passes,
`/`-separated keys pass, `../` traversal throws, sibling-prefix escape throws. Written test-first
(RED confirmed before the fix). Full suite green (`npm run unitTest`): 51 passing.

#### End-to-end validation
Beyond the unit tests, the fix was validated live against real orgs and the real CLI:

**1. Live exploit reproduction through the real `packExpandFile` command.** Crafted an
attacker-authored DataPack file with `VlocityDataPackKey: "../../../ESCAPED/pwned.json"` +
`SFDXData` payload, and ran the actual `packExpandFile` verb (→ `expandFile` → `expand` →
`expandSFDX`) against a sandboxed SFDX project.
- **Pre-fix (`master`):** log `Writing SFDX File >> ../../../.../ESCAPED/pwned.json`, `ExpandFile success`
  — the payload was written **outside** the project's `force-app` dir. Arbitrary file write confirmed.
- **With fix:** `Path traversal detected: refusing to write outside SFDX project directory`, caught by
  `expandFile`'s existing `try/catch` as `Invalid DataPackFile` — **no file written anywhere**.

**2. Deploy + activate regression on a real 1P org (proves no functional impact).** Ran the
standard 5-OmniScript deploy job (`packDeploy`, `activate: true`) against `1p-sb164` with the fix in
place, verified via org state (not the CLI's "N Completed" line):
- All 5 Claim OmniScripts activated at their new versions (e.g. `Claim/AddAttachments` newest
  version `IsActive=true` with ≥1 `OmniProcessCompilation` row).
- Zero failed activation `AsyncApexJob`s after the run watermark.

This confirms the guard is a **no-op on the deploy path** — `packDeploy` → `deployJob` reads local
DataPacks via `buildImport` and pushes to the org via `source:convert`/`mdapi:deploy`; it never
populates `SFDXData`, so `expandSFDX`'s write body (gated by `if (dataPack.SFDXData)`) is never
reached. The vulnerability lives on the **import/expand** direction (`packExpandFile` / export /
retrieve), exactly the ticket's stated precondition, which validation **1** exercises.

