### PR TITLE
@W-24135584: write SFDX credentials file with owner-only permissions

### DIFF
--- a/lib/utilityservice.js
+++ b/lib/utilityservice.js
@@ -353,7 +353,8 @@ UtilityService.prototype.sfdxLogin = async function() {
         orgInfo.vbtSfdxUsername = this.vlocity.sfdxUsername;
 
         try {
-            fs.outputFileSync(credentialsFile, JSON.stringify(orgInfo, null, 4));
+            fs.outputFileSync(credentialsFile, JSON.stringify(orgInfo, null, 4), { mode: 0o600 });
+            fs.chmodSync(credentialsFile, 0o600);
         } catch (ex) {
             VlocityUtils.error('Error Saving SFDX Credentials', ex);
         }


### PR DESCRIPTION
sfdxLogin() persisted the refreshed org credentials (orgInfo - includes accessToken and, via 'org display --verbose', sfdxAuthUrl, a refresh-equivalent secret) to credentialsFile via fs.outputFileSync with no explicit mode. The file was created under the process default umask (commonly group/world-readable), so another local principal on a shared build host could read it and reuse the session (CWE-732).

Pass { mode: 0o600 } to outputFileSync for the create case, and chmodSync the file to 0o600 afterward so a pre-existing file from a prior (unpatched) run also gets corrected on the next login, since fs.writeFile's mode option only applies when the file is newly created.