### PR TITLE
@W-24123452@ Escape SOQL literals in OmniScript activation searchKey (CWE-89)

### DIFF
--- a/lib/datapacktypes/omniscript.js
+++ b/lib/datapacktypes/omniscript.js
@@ -11,6 +11,15 @@ var OmniScript = module.exports = function (vlocity) {
 
 var OMNI_BULK_RECORDS_LIMIT_MIN = 1000;
 
+// Escape backslash and single-quote before embedding a value in a single-quoted
+// SOQL literal: neutralizes CWE-89 breakout and lets legitimate Type/SubType/
+// Language values containing an apostrophe query correctly. Preserves the prior
+// template-literal coercion (null/undefined -> "null"/"undefined").
+function escapeSOQLValue(value) {
+    return `${value}`.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+OmniScript.escapeSOQLValue = escapeSOQLValue;
+
 // Returns an Object of label to value used in the field diff. 
 OmniScript.prototype.createTitleObjects = function (input) {
     var dataPackData = input.dataPackData;
@@ -174,7 +183,7 @@ OmniScript.prototype.afterActivationSuccess = async function (inputMap) {
                                                                                 ${nsPrefix}OmniScriptId__r.${nsPrefix}SubType__c, 
                                                                                 ${nsPrefix}OmniScriptId__r.${nsPrefix}Language__c 
                                                                         FROM ${nsPrefix}Element__c 
-                                                                        WHERE ${nsPrefix}SearchKey__c = '${searchKey}' AND ${nsPrefix}OmniScriptId__r.${nsPrefix}IsActive__c = true`
+                                                                        WHERE ${nsPrefix}SearchKey__c = '${escapeSOQLValue(searchKey)}' AND ${nsPrefix}OmniScriptId__r.${nsPrefix}IsActive__c = true`
                                     )
                                 );
             for (var i = 0; i < reusableOmnis.records.length; i++) {
@@ -208,9 +217,9 @@ OmniScript.prototype.onDeployFinish = async function (jobInfo) {
                 let type = omniScript[`${nsPrefix}OmniScriptId__r`][`${nsPrefix}Type__c`];
                 let subType = omniScript[`${nsPrefix}OmniScriptId__r`][`${nsPrefix}SubType__c`];
                 let lang = omniScript[`${nsPrefix}OmniScriptId__r`][`${nsPrefix}Language__c`];
-                query = this.vlocity.omnistudio.updateQuery(`SELECT Id FROM ${nsPrefix}OmniScript__c WHERE ${nsPrefix}Type__c = '${type}' AND ${nsPrefix}SubType__c = '${subType}' AND ${nsPrefix}Language__c = '${lang}' AND ${nsPrefix}IsActive__c = true`);
+                query = this.vlocity.omnistudio.updateQuery(`SELECT Id FROM ${nsPrefix}OmniScript__c WHERE ${nsPrefix}Type__c = '${escapeSOQLValue(type)}' AND ${nsPrefix}SubType__c = '${escapeSOQLValue(subType)}' AND ${nsPrefix}Language__c = '${escapeSOQLValue(lang)}' AND ${nsPrefix}IsActive__c = true`);
             } else {
-                query = this.vlocity.omnistudio.updateQuery(`SELECT Id FROM ${nsPrefix}OmniScript__c WHERE ${nsPrefix}Type__c = '${omniScript.OmniProcess.Type}' AND ${nsPrefix}SubType__c = '${omniScript.OmniProcess.SubType}' AND ${nsPrefix}Language__c = '${omniScript.OmniProcess.Language}' AND ${nsPrefix}IsActive__c = true`);
+                query = this.vlocity.omnistudio.updateQuery(`SELECT Id FROM ${nsPrefix}OmniScript__c WHERE ${nsPrefix}Type__c = '${escapeSOQLValue(omniScript.OmniProcess.Type)}' AND ${nsPrefix}SubType__c = '${escapeSOQLValue(omniScript.OmniProcess.SubType)}' AND ${nsPrefix}Language__c = '${escapeSOQLValue(omniScript.OmniProcess.Language)}' AND ${nsPrefix}IsActive__c = true`);
             }
 
             let parentOmniScript = await this.vlocity.jsForceConnection.query(query);
@@ -474,7 +483,7 @@ OmniScript.prototype.onActivateError = async function (dataPackData) {
             return onActivateErrorResult;
         }
 
-        let reusableOmnis = await this.vlocity.jsForceConnection.query(this.vlocity.omnistudio.updateQuery(`SELECT Id, ${this.vlocity.namespacePrefix}OmniScriptId__c FROM ${this.vlocity.namespacePrefix}Element__c WHERE ${this.vlocity.namespacePrefix}SearchKey__c = '${searchKey}' AND ${this.vlocity.namespacePrefix}OmniScriptId__r.${this.vlocity.namespacePrefix}IsActive__c = true`));
+        let reusableOmnis = await this.vlocity.jsForceConnection.query(this.vlocity.omnistudio.updateQuery(`SELECT Id, ${this.vlocity.namespacePrefix}OmniScriptId__c FROM ${this.vlocity.namespacePrefix}Element__c WHERE ${this.vlocity.namespacePrefix}SearchKey__c = '${escapeSOQLValue(searchKey)}' AND ${this.vlocity.namespacePrefix}OmniScriptId__r.${this.vlocity.namespacePrefix}IsActive__c = true`));
         
         for (var i = 0; i < reusableOmnis.records.length; i++) {
             

--- a/test/omniscript.spec.js
+++ b/test/omniscript.spec.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const _omniscript = require('../lib/datapacktypes/omniscript');
+const _vlocityutils = require('../lib/vlocityutils');
+
+const expect = require('chai').expect;
+
+describe('OmniScript.escapeSOQLValue', () => {
+  const escape = _omniscript.escapeSOQLValue;
+
+  it('should be a function', () => {
+    expect(escape).to.be.a('function');
+  });
+
+  it('leaves ordinary Type/SubType/Language values unchanged', () => {
+    expect(escape('Claim')).to.eq('Claim');
+    expect(escape('AddAttachments')).to.eq('AddAttachments');
+    expect(escape('English')).to.eq('English');
+  });
+
+  it('escapes a legitimate apostrophe so the SOQL literal stays valid (functional bug)', () => {
+    expect(escape("O'Brien")).to.eq("O\\'Brien");
+  });
+
+  it('neutralizes a SOQL-injection breakout attempt (CWE-89)', () => {
+    // Without escaping this closes the literal and appends a predicate.
+    const attack = "x' OR Name != '";
+    expect(escape(attack)).to.eq("x\\' OR Name != \\'");
+    // No unescaped single quote survives.
+    expect(escape(attack).replace(/\\'/g, '')).to.not.contain("'");
+  });
+
+  it('escapes backslash before the quote (no escape-the-escape bypass)', () => {
+    expect(escape("a\\'b")).to.eq("a\\\\\\'b");
+  });
+
+  it('preserves the prior template-literal coercion for null/undefined', () => {
+    expect(escape(undefined)).to.eq('undefined');
+    expect(escape(null)).to.eq('null');
+  });
+});


### PR DESCRIPTION
### What

Escape single-quote / backslash before embedding DataPack-sourced
`Type__c` / `SubType__c` / `Language__c` values into single-quoted SOQL
string literals during OmniScript DataPack activation.

Adds a small module-level `escapeSOQLValue()` in
`lib/datapacktypes/omniscript.js` and applies it at the four query sites
that build a `SearchKey__c` / `Type__c`/`SubType__c`/`Language__c`
predicate from DataPack field values:

- `SearchKey__c = '...'` in `onDeploy` reusable-OS lookup (~L177)
- `Type__c`/`SubType__c`/`Language__c` predicates in `onDeployFinish` (~L211, ~L213)
- `SearchKey__c = '...'` in the direct reusable-OS activation path (~L477)

### Why

W-24123452 (CWE-89). These fields were interpolated unescaped, so a value
containing a single quote broke out of the SOQL literal. Two concrete
consequences:

1. **Functional bug** — a legitimate OmniScript whose Type/SubType/Language
   contains an apostrophe produced malformed SOQL and a failed query.
2. **Defense-in-depth** — removes the string-injection primitive. (In VBT's
   actual usage the practical security risk is low: the query runs in the
   build-runner's own user-mode session and only selects OmniScripts to
   recompile — the DataPack author already has deploy privileges. This is a
   hardening / robustness fix, not a fix for a demonstrated privilege-crossing
   exploit.)

### How escaping works

`escapeSOQLValue()` coerces via template literal (preserving the prior
`null`/`undefined` -> `"null"`/`"undefined"` behavior), then escapes
backslash first, then single-quote — the correct order for a single-quoted
SOQL literal (no escape-the-escape bypass). Values without quotes/backslashes
are unchanged, so no behavior change for normal DataPacks.

### Testing

- New `test/omniscript.spec.js` — 6 cases covering pass-through, apostrophe,
  injection breakout, backslash ordering, null/undefined coercion.
- `npm run unitTest` — full suite green, no regressions.

### Live deploy + activate verification

Beyond unit tests, the change was exercised end to end with a real
deploy + activate against a 1P support sandbox, using this patched build of
VBT, to confirm the changed reusable-OmniScript activation query path still
works with real (quote-free) values:

1. **Start from a clean baseline** — confirmed the org had 0 active OmniScripts
   embedding the reusable child (so activation wouldn't hit the unrelated
   governor-limit cascade), and recorded a timestamp watermark of the latest
   activation async job.
2. **Deploy + activate** a manifest-scoped job of 5 OmniScripts with
   `activate: true` (`packDeploy`), run via this branch's code
   (`node lib/vlocitybuild.js -sfdx.username <org> -job <job>.yaml packDeploy`).
   All 5 deployed, activated, and LWC-activated with `Error = 0`.
3. **Verify via org state, not the CLI summary line** (which reports success
   even when async activation retried): the deployed script showed its **new
   version `IsActive = true`** with an `OmniProcessCompilation` row, and **no
   activation async jobs failed** after the watermark.

Result: normal deploy/activate is unaffected — expected, since the escape is a
no-op for any value without a quote or backslash.
